### PR TITLE
Improve motion reduction detection

### DIFF
--- a/frontend/src/lib/stores/reducedMotion.spec.ts
+++ b/frontend/src/lib/stores/reducedMotion.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { reducedMotion, motionNoticeVisible } from './reducedMotion';
-import * as device from '../utils/device';
+import { describe, it, expect, vi } from "vitest";
+import { reducedMotion, motionNoticeVisible } from "./reducedMotion";
+import * as device from "../utils/device";
 
 /**
  * ! Utilidad para obtener el valor actual de un store Svelte.
@@ -10,10 +10,10 @@ import * as device from '../utils/device';
  */
 
 function getValue(store: any) {
-    let value: any;
-    const unsubscribe = store.subscribe((v: any) => (value = v));
-    unsubscribe();
-    return value;
+  let value: any;
+  const unsubscribe = store.subscribe((v: any) => (value = v));
+  unsubscribe();
+  return value;
 }
 
 /**
@@ -25,29 +25,45 @@ function getValue(store: any) {
  * - Verifica que el aviso no se oculte al cambiar la preferencia de animaciones.
  */
 
-describe('reducedMotion store', () => {
-    // Simula un dispositivo de bajo rendimiento y verifica el comportamiento esperado
-    it('activates and shows notice on low-end device', () => {
-        vi.spyOn(device, 'isLowEndDevice').mockReturnValue(true);
-        const html = document.documentElement;
-        html.classList.remove('reduced-motion');
+describe("reducedMotion store", () => {
+  // Simula un dispositivo de bajo rendimiento y verifica el comportamiento esperado
+  it("activates and shows notice on low-end device", () => {
+    vi.spyOn(device, "isLowEndDevice").mockReturnValue(true);
+    vi.spyOn(device, "hasSlowConnection").mockReturnValue(false);
+    const html = document.documentElement;
+    html.classList.remove("reduced-motion");
 
-        const val = getValue(reducedMotion);
-        expect(val).toBe(true); // reducedMotion debe estar activo
-        expect(getValue(motionNoticeVisible)).toBe(true); // El aviso debe mostrarse
-        expect(html.classList.contains('reduced-motion')).toBe(true); // La clase debe estar en <html>
-    });
+    const val = getValue(reducedMotion);
+    expect(val).toBe(true); // reducedMotion debe estar activo
+    expect(getValue(motionNoticeVisible)).toBe(true); // El aviso debe mostrarse
+    expect(html.classList.contains("reduced-motion")).toBe(true); // La clase debe estar en <html>
+  });
 
-    // Verifica que al cambiar el store se actualice la clase en <html>
-    it('toggle updates class', () => {
-        reducedMotion.set(false);
-        expect(document.documentElement.classList.contains('reduced-motion')).toBe(false);
-    });
+  // Verifica que al cambiar el store se actualice la clase en <html>
+  it("toggle updates class", () => {
+    reducedMotion.set(false);
+    expect(document.documentElement.classList.contains("reduced-motion")).toBe(
+      false,
+    );
+  });
 
-    // Verifica que el aviso no se oculte al cambiar la preferencia de animaciones
-    it('does not hide notice when toggling', () => {
-        motionNoticeVisible.set(true);
-        reducedMotion.set(false);
-        expect(getValue(motionNoticeVisible)).toBe(true);
-    });
+  // Simula una conexión lenta y verifica que se active la reducción de animaciones
+  it("activates on slow connection", () => {
+    vi.spyOn(device, "isLowEndDevice").mockReturnValue(false);
+    vi.spyOn(device, "hasSlowConnection").mockReturnValue(true);
+    document.documentElement.classList.remove("reduced-motion");
+
+    const val = getValue(reducedMotion);
+    expect(val).toBe(true);
+    expect(document.documentElement.classList.contains("reduced-motion")).toBe(
+      true,
+    );
+  });
+
+  // Verifica que el aviso no se oculte al cambiar la preferencia de animaciones
+  it("does not hide notice when toggling", () => {
+    motionNoticeVisible.set(true);
+    reducedMotion.set(false);
+    expect(getValue(motionNoticeVisible)).toBe(true);
+  });
 });

--- a/frontend/src/lib/stores/reducedMotion.ts
+++ b/frontend/src/lib/stores/reducedMotion.ts
@@ -1,6 +1,6 @@
-import { writable, get } from 'svelte/store';
-import { browser } from '$app/environment';
-import { isLowEndDevice } from '../utils/device';
+import { writable, get } from "svelte/store";
+import { browser } from "$app/environment";
+import { isLowEndDevice, hasSlowConnection } from "../utils/device";
 
 // * Indica si la reducción se activó automáticamente por el dispositivo
 export const autoReducedMotion = writable(false);
@@ -9,65 +9,85 @@ export const autoReducedMotion = writable(false);
 export const motionNoticeVisible = writable(false);
 
 function createReducedMotion() {
-    const store = writable(false);
+  const store = writable(false);
 
-    if (browser) {
-        const stored = localStorage.getItem('reducedMotion');
-        const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+  if (browser) {
+    const stored = localStorage.getItem("reducedMotion");
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
 
-        const auto = stored === null && isLowEndDevice();
-        autoReducedMotion.set(auto);
+    const auto = stored === null && (isLowEndDevice() || hasSlowConnection());
+    autoReducedMotion.set(auto);
 
-        const initial = stored !== null ? JSON.parse(stored) : query.matches || auto;
-        document.documentElement.classList.toggle('reduced-motion', initial);
-        store.set(initial);
+    const initial =
+      stored !== null ? JSON.parse(stored) : query.matches || auto;
+    document.documentElement.classList.toggle("reduced-motion", initial);
+    store.set(initial);
 
-        // Mostrar aviso si el dispositivo es lento o el sistema tiene preferencia reducida
-        if (isLowEndDevice() || query.matches) {
-            motionNoticeVisible.set(true);
+    // Mostrar aviso si el dispositivo es lento o el sistema tiene preferencia reducida
+    if (isLowEndDevice() || hasSlowConnection() || query.matches) {
+      motionNoticeVisible.set(true);
+    }
+
+    // Escuchar cambios en la preferencia del sistema
+    const mqHandler = (e: MediaQueryListEvent) => {
+      if (stored === null) {
+        const val = e.matches || isLowEndDevice() || hasSlowConnection();
+        document.documentElement.classList.toggle("reduced-motion", val);
+        store.set(val);
+        autoReducedMotion.set(isLowEndDevice() || hasSlowConnection());
+        if (isLowEndDevice() || hasSlowConnection() || e.matches) {
+          motionNoticeVisible.set(true);
         }
-
-        // Escuchar cambios en la preferencia del sistema
-        const handler = (e: MediaQueryListEvent) => {
-            if (stored === null) {
-                const val = e.matches || isLowEndDevice();
-                document.documentElement.classList.toggle('reduced-motion', val);
-                store.set(val);
-                autoReducedMotion.set(isLowEndDevice());
-                if (isLowEndDevice() || e.matches) {
-                    motionNoticeVisible.set(true);
-                }
-            }
-        };
-
-        query.addEventListener('change', handler);
-    }
-
-    function set(value: boolean) {
-        store.set(value);
-        if (browser) {
-            document.documentElement.classList.toggle('reduced-motion', value);
-            localStorage.setItem('reducedMotion', JSON.stringify(value));
-            autoReducedMotion.set(false); // el usuario hizo override
-
-            // El aviso solo se oculta si el dispositivo no es lento y no hay preferencia del sistema
-            if (!isLowEndDevice() && !window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-                motionNoticeVisible.set(value);
-            } else {
-                motionNoticeVisible.set(true); // se mantiene visible aunque se activen las animaciones
-            }
-        }
-    }
-
-    function toggle() {
-        set(!get(store));
-    }
-
-    return {
-        subscribe: store.subscribe,
-        set,
-        toggle
+      }
     };
+
+    const connection = (navigator as any).connection;
+
+    const connHandler = () => {
+      if (stored === null) {
+        const val = query.matches || isLowEndDevice() || hasSlowConnection();
+        document.documentElement.classList.toggle("reduced-motion", val);
+        store.set(val);
+        autoReducedMotion.set(isLowEndDevice() || hasSlowConnection());
+        if (isLowEndDevice() || hasSlowConnection() || query.matches) {
+          motionNoticeVisible.set(true);
+        }
+      }
+    };
+
+    query.addEventListener("change", mqHandler);
+    connection?.addEventListener("change", connHandler);
+  }
+
+  function set(value: boolean) {
+    store.set(value);
+    if (browser) {
+      document.documentElement.classList.toggle("reduced-motion", value);
+      localStorage.setItem("reducedMotion", JSON.stringify(value));
+      autoReducedMotion.set(false); // el usuario hizo override
+
+      // El aviso solo se oculta si el dispositivo no es lento y no hay preferencia del sistema
+      if (
+        !isLowEndDevice() &&
+        !hasSlowConnection() &&
+        !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      ) {
+        motionNoticeVisible.set(value);
+      } else {
+        motionNoticeVisible.set(true); // se mantiene visible aunque se activen las animaciones
+      }
+    }
+  }
+
+  function toggle() {
+    set(!get(store));
+  }
+
+  return {
+    subscribe: store.subscribe,
+    set,
+    toggle,
+  };
 }
 
 export const reducedMotion = createReducedMotion();

--- a/frontend/src/lib/utils/device.ts
+++ b/frontend/src/lib/utils/device.ts
@@ -3,16 +3,27 @@
  * -*- Se centraliza la detección de dispositivos poco potentes para reutilizar la lógica y facilitar las pruebas unitarias.
  */
 
-export function isLowEndDevice(navigatorObject: Navigator = navigator): boolean {
-    // ! Heurísticas simples: núcleos, memoria, conexión lenta o móvil
-    const nav = navigatorObject as any;
-    const cores = nav.hardwareConcurrency ?? 8;
-    const memory = nav.deviceMemory ?? 8;
-    const conn = nav.connection as any;
-    const slowConn = /2g/.test(conn?.effectiveType ?? '');
-    const saveData = conn?.saveData ?? false;
-    const ua = navigatorObject.userAgent ?? '';
-    const isMobile = /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
+export function hasSlowConnection(
+  navigatorObject: Navigator = navigator,
+): boolean {
+  const conn = (navigatorObject as any).connection;
+  if (!conn) return false;
+  const { effectiveType, downlink = 10, saveData = false } = conn as any;
+  return saveData || /(2g|slow-2g)/i.test(effectiveType ?? "") || downlink < 1;
+}
 
-    return cores <= 4 || memory <= 4 || slowConn || saveData || isMobile;
+export function isLowEndDevice(
+  navigatorObject: Navigator = navigator,
+): boolean {
+  // ! Heurísticas simples: núcleos, memoria, conexión o dispositivo móvil
+  const nav = navigatorObject as any;
+  const cores = nav.hardwareConcurrency ?? 8;
+  const memory = nav.deviceMemory ?? 8;
+  const ua = navigatorObject.userAgent ?? "";
+  const isMobile =
+    /Mobi|Android|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
+
+  return (
+    cores <= 4 || memory <= 4 || hasSlowConnection(navigatorObject) || isMobile
+  );
 }


### PR DESCRIPTION
## Summary
- detect slow connections separately from low-end devices
- auto-toggle motion reduction when network conditions change
- update tests for new behavior

## Testing
- `npm run test:unit -- --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6c3310d08325bd8d8d7336abb0f9