### PR TITLE
Replace CSS animations with MotionOne

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,8 @@
 		"@tailwindcss/typography": "^0.5.16",
 		"clsx": "^2.1.1",
 		"solid-js": "^1.9.7",
-		"solid-motionone": "^1.0.4",
-		"tailwindcss": "^4.1.7"
-	}
+                "solid-motionone": "^1.0.4",
+                "tailwindcss": "^4.1.7",
+                "@motionone/svelte": "^10.16.0"
+        }
 }

--- a/frontend/src/lib/components/feedback/Loader.svelte
+++ b/frontend/src/lib/components/feedback/Loader.svelte
@@ -19,11 +19,12 @@
 -->
 
 <script lang="ts">
-        export let size: number = 50;
-        export let loading = false;
-        export let message: string = 'Cargando...';
-        export let overlayColor: string = '#ffffff';
-        export let overlayOpacity: number = 0.6;
+  import { Motion } from '@motionone/svelte';
+  export let size: number = 50;
+  export let loading = false;
+  export let message: string = 'Cargando...';
+  export let overlayColor: string = '#ffffff';
+  export let overlayOpacity: number = 0.6;
 </script>
 
 {#if loading}
@@ -32,46 +33,22 @@
                 style={`background-color: ${overlayColor}; opacity: ${overlayOpacity};`}
         >
                 <div class="pointer-events-auto relative flex flex-col items-center justify-center">
-                        <img
+                        <Motion.img
                                 src="/logo-2.png"
                                 alt={message}
-                                class="animate-pulse-soft"
+                                animate={{ scale: [1, 1.1, 1], opacity: [0.6, 1, 0.6] }}
+                                transition={{ duration: 1.8, repeat: Infinity }}
                                 style={`width: ${size}px; height: ${size}px; opacity: 0.85; filter: drop-shadow(0 0 5px rgba(0,0,0,0.1));`}
                         />
-                        <span class="animate-fade-in mt-2 text-sm text-gray-500">{message}</span>
+                        <Motion.span
+                                animate={{ opacity: [0, 1], y: [4, 0] }}
+                                transition={{ duration: 0.6 }}
+                                class="mt-2 text-sm text-gray-500"
+                        >{message}</Motion.span>
                 </div>
         </div>
 {/if}
 
 <style>
-	@keyframes pulse-soft {
-		0%,
-		100% {
-			transform: scale(1);
-			opacity: 0.6;
-		}
-		50% {
-			transform: scale(1.1);
-			opacity: 1;
-		}
-	}
-
-	@keyframes fade-in {
-		from {
-			opacity: 0;
-			transform: translateY(4px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
-
-	.animate-pulse-soft {
-		animation: pulse-soft 1.8s ease-in-out infinite;
-	}
-
-	.animate-fade-in {
-		animation: fade-in 0.6s ease-out forwards;
-	}
+        /* Animaciones reemplazadas por MotionOne */
 </style>

--- a/frontend/src/lib/components/feedback/MotionNotice.svelte
+++ b/frontend/src/lib/components/feedback/MotionNotice.svelte
@@ -5,9 +5,10 @@
 -->
 
 <script lang="ts">
-	import { reducedMotion, motionNoticeVisible } from '$lib/stores/reducedMotion';
-	import { onMount, onDestroy, tick } from 'svelte';
-	import { browser } from '$app/environment';
+  import { reducedMotion, motionNoticeVisible } from '$lib/stores/reducedMotion';
+  import { onMount, onDestroy, tick } from 'svelte';
+  import { browser } from '$app/environment';
+  import { Motion } from '@motionone/svelte';
 
 	let show = false;
 	let expanded = false;
@@ -57,43 +58,44 @@
 </script>
 
 {#if show}
-	<div
-		class="fixed bottom-5 left-5 z-[130] cursor-pointer"
-		role="button"
-		tabindex="0"
-		aria-live="polite"
-		on:click={handleClick}
-		on:keydown={(e) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				handleClick(e);
-				e.preventDefault();
-			}
-		}}
-	>
-		<div
-			class={`flex items-center gap-3 overflow-hidden transition-all duration-700 ease-in-out
-			${expanded ? 'max-w-[calc(100vw-2.5rem)] pr-4 sm:max-w-[24rem]' : 'h-14 w-14 justify-center'}
-			border-2 border-red-200 bg-gradient-to-br from-white/90 to-red-50 p-2 shadow-xl ring-1 ring-red-300 backdrop-blur-sm
-			${animateIcon ? 'animate-entry' : ''}
-			hover:shadow-red-pulse`}
-			style="border-radius: {expanded ? '0.75rem' : '9999px'};"
-		>
+        <Motion.div
+                class="fixed bottom-5 left-5 z-[130] cursor-pointer"
+                role="button"
+                tabindex="0"
+                aria-live="polite"
+                on:click={handleClick}
+                on:keydown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                                handleClick(e);
+                                e.preventDefault();
+                        }
+                }}
+        >
+                <Motion.div
+                        class={`flex items-center gap-3 overflow-hidden
+                        ${expanded ? 'max-w-[calc(100vw-2.5rem)] pr-4 sm:max-w-[24rem]' : 'h-14 w-14 justify-center'}
+                        border-2 border-red-200 bg-gradient-to-br from-white/90 to-red-50 p-2 shadow-xl ring-1 ring-red-300 backdrop-blur-sm
+                        hover:shadow-red-pulse`}
+                        animate={{ borderRadius: expanded ? '0.75rem' : '9999px' }}
+                        transition={{ duration: 0.7, easing: 'ease-in-out' }}
+                >
 			<!-- Ícono de advertencia -->
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				fill="none"
-				viewBox="0 0 24 24"
-				stroke-width="2"
-				stroke="currentColor"
-				class={`h-5 w-5 shrink-0 text-red-600 transition-transform duration-300 ease-out
-					${!expanded ? 'motion-icon-hover' : ''}`}
-			>
+                        <Motion.svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke-width="2"
+                                stroke="currentColor"
+                                class="h-5 w-5 shrink-0 text-red-600"
+                                whileHover={!expanded ? { rotate: [0,-5,3,-2,0], scale:[1,1.08,1.05,1.02,1] } : undefined}
+                                transition={{ duration: 0.6 }}
+                        >
 				<path
 					stroke-linecap="round"
 					stroke-linejoin="round"
 					d="M12 9v3m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.665 1.732-3L13.732 4c-.77-1.335-2.694-1.335-3.464 0L3.34 17c-.77 1.335.192 3 1.732 3z"
-				/>
-			</svg>
+                                />
+                        </Motion.svg>
 
 			{#if expanded}
 				<span
@@ -108,47 +110,11 @@
 				>
 					{$reducedMotion ? 'Habilitar' : 'Deshabilitar'}
 				</button>
-			{/if}
-		</div>
-	</div>
+                        {/if}
+                </Motion.div>
+        </Motion.div>
 {/if}
 
 <style>
-	@keyframes entry {
-		0% {
-			transform: scale(1);
-		}
-		25% {
-			transform: scale(1.1) rotate(-1.5deg);
-		}
-		50% {
-			transform: scale(1.03) rotate(1.5deg);
-		}
-		100% {
-			transform: scale(1);
-		}
-	}
-	.animate-entry {
-		animation: entry 0.9s ease-out 1;
-	}
-	.motion-icon-hover:hover {
-		animation: warning-pulse 0.6s ease-in-out 1;
-	}
-	@keyframes warning-pulse {
-		0% {
-			transform: rotate(0deg) scale(1);
-		}
-		25% {
-			transform: rotate(-5deg) scale(1.08);
-		}
-		50% {
-			transform: rotate(3deg) scale(1.05);
-		}
-		75% {
-			transform: rotate(-2deg) scale(1.02);
-		}
-		100% {
-			transform: rotate(0deg) scale(1);
-		}
-	}
+        /* Animaciones reemplazadas por MotionOne */
 </style>

--- a/frontend/src/lib/components/home/CallToActionSection.svelte
+++ b/frontend/src/lib/components/home/CallToActionSection.svelte
@@ -9,13 +9,14 @@ TODO:
 -->
 
 <script lang="ts">
-	import { onMount } from 'svelte';
-       import Badge from '$lib/components/ui/elements/Badge.svelte';
-       import Image from '$lib/components/ui/elements/Image.svelte';
-       import Button from '$lib/components/ui/elements/Button.svelte';
+  import { onMount } from 'svelte';
+  import { Motion } from '@motionone/svelte';
+  import Badge from '$lib/components/ui/elements/Badge.svelte';
+  import Image from '$lib/components/ui/elements/Image.svelte';
+  import Button from '$lib/components/ui/elements/Button.svelte';
 
-	let visible = false;
-	let sectionRef: HTMLDivElement;
+  let visible = false;
+  let sectionRef: HTMLDivElement;
 
 	onMount(() => {
 		const io = new IntersectionObserver(
@@ -35,12 +36,11 @@ TODO:
 		class="mx-auto flex max-w-7xl flex-col-reverse items-center justify-between gap-8 md:gap-12 lg:flex-row"
 	>
 		<!-- *Lado izquierdo: texto -->
-		<div
-			class="flex-1 space-y-5 text-center text-white lg:text-left"
-			class:fade-in-left={visible}
-			class:fade-out-left={!visible}
-			style="transition-delay: .05s"
-		>
+                <Motion.div
+                        class="flex-1 space-y-5 text-center text-white lg:text-left"
+                        animate={{ opacity: visible ? 1 : 0, translateY: visible ? 0 : 60, scale: visible ? 1 : 0.96, filter: visible ? 'blur(0px)' : 'blur(8px)' }}
+                        transition={{ duration: 0.95, delay: 0.05 }}
+                >
 			<!-- *Badge: variante corta en mobile, larga en desktop -->
 			<div class="flex justify-center backdrop-blur lg:justify-start">
 				<Badge text="Beneficios más allá de la conexión" customClass="inline-flex sm:hidden" />
@@ -50,27 +50,27 @@ TODO:
 				/>
 			</div>
 			<!-- *h2 (sin <br> en mobile, con <br> en desktop) -->
-			<h2
-				class="cta-animate-title text-2xl font-extrabold leading-tight drop-shadow sm:text-3xl md:text-4xl"
-			>
+                        <Motion.h2
+                                class="text-2xl font-extrabold leading-tight drop-shadow sm:text-3xl md:text-4xl"
+                                animate={{ opacity: visible ? 1 : 0, y: visible ? 0 : 60, filter: visible ? 'blur(0px)' : 'blur(7px)' }}
+                                transition={{ duration: 1.1, delay: 0.17 }}
+                        >
 				<span class="sm:hidden">Descubrí lo que ganás al ser parte de esta red solidaria.</span>
 				<span class="hidden sm:inline"
 					>Descubrí lo que ganás al<br />ser parte de esta red solidaria.</span
 				>
-			</h2>
-			<p
-				class="mx-auto mb-9 max-w-lg text-base font-medium text-blue-100/85 drop-shadow-sm transition-opacity duration-500 lg:mx-0"
-				class:fade-in-left={visible}
-				class:fade-out-left={!visible}
-				style="transition-delay: .18s"
-			>
+                        </Motion.h2>
+                        <Motion.p
+                                class="mx-auto mb-9 max-w-lg text-base font-medium text-blue-100/85 drop-shadow-sm lg:mx-0"
+                                animate={{ opacity: visible ? 1 : 0, translateY: visible ? 0 : 60, scale: visible ? 1 : 0.96, filter: visible ? 'blur(0)' : 'blur(8px)' }}
+                                transition={{ duration: 0.95, delay: 0.18 }}
+                        >
 				Cada conexión puede transformar una vida, incluso la tuya.
 			</p>
-			<div
-				class:fade-in-left={visible}
-				class:fade-out-left={!visible}
-				style="transition-delay: .3s"
-			>
+                        <Motion.div
+                                animate={{ opacity: visible ? 1 : 0, translateY: visible ? 0 : 60, scale: visible ? 1 : 0.96, filter: visible ? 'blur(0)' : 'blur(8px)' }}
+                                transition={{ duration: 0.95, delay: 0.3 }}
+                        >
 				<!-- !Button solo visible en mobile -->
 				<div class="sm:hidden">
 					<Button label="Registrate y generá impacto" href="/registro" variant="ghost" size="sm" />
@@ -83,17 +83,16 @@ TODO:
 						variant="ghost"
 						size="md"
 					/>
-				</div>
-			</div>
+                        </Motion.div>
+                </Motion.div>
 		</div>
 
 		<!-- *Lado derecho: imagen -->
-		<div
-			class="flex flex-1 items-end justify-center"
-			class:fade-in-right={visible}
-			class:fade-out-right={!visible}
-			style="transition-delay: .23s"
-		>
+                <Motion.div
+                        class="flex flex-1 items-end justify-center"
+                        animate={{ opacity: visible ? 1 : 0, translateY: visible ? 0 : 60, scale: visible ? 1 : 0.95, filter: visible ? 'blur(0)' : 'blur(10px)' }}
+                        transition={{ duration: 1, delay: 0.23 }}
+                >
 			<div
 				class="cta-img-outer group relative h-64 w-44 overflow-visible rounded-[2rem] shadow-xl shadow-blue-950/20 ring-2 ring-blue-400/10 transition-all duration-500 hover:ring-blue-400/30 sm:h-[460px] sm:w-[320px] md:h-[480px] md:w-[350px]"
 			>
@@ -111,60 +110,10 @@ TODO:
 					</div>
 				</div>
 			</div>
-		</div>
-	</div>
+                </Motion.div>
+        </div>
 </section>
 
 <style>
-	.fade-in-left {
-		opacity: 1;
-		transform: translateY(0) scale(1);
-		filter: blur(0);
-		transition:
-			opacity 0.95s cubic-bezier(0.43, 0, 0.22, 1),
-			transform 1s cubic-bezier(0.43, 0, 0.22, 1),
-			filter 0.95s cubic-bezier(0.43, 0, 0.22, 1);
-	}
-	.fade-out-left {
-		opacity: 0;
-		transform: translateY(60px) scale(0.96);
-		filter: blur(8px);
-		transition:
-			opacity 0.95s cubic-bezier(0.43, 0, 0.22, 1),
-			transform 1s cubic-bezier(0.43, 0, 0.22, 1),
-			filter 0.95s cubic-bezier(0.43, 0, 0.22, 1);
-	}
-	.fade-in-right {
-		opacity: 1;
-		transform: translateY(0) scale(1);
-		filter: blur(0);
-		transition:
-			opacity 1.1s 0.18s cubic-bezier(0.45, 0, 0.18, 1),
-			transform 1s 0.18s cubic-bezier(0.45, 0, 0.18, 1),
-			filter 1s 0.18s cubic-bezier(0.45, 0, 0.18, 1);
-	}
-	.fade-out-right {
-		opacity: 0;
-		transform: translateY(60px) scale(0.95);
-		filter: blur(10px);
-		transition:
-			opacity 1.1s 0.18s cubic-bezier(0.45, 0, 0.18, 1),
-			transform 1s 0.18s cubic-bezier(0.45, 0, 0.18, 1),
-			filter 1s 0.18s cubic-bezier(0.45, 0, 0.18, 1);
-	}
-	.cta-animate-title {
-		animation: fadeInUp 1.1s 0.17s cubic-bezier(0.45, 0, 0.18, 1) both;
-	}
-	@keyframes fadeInUp {
-		0% {
-			opacity: 0;
-			transform: translateY(60px);
-			filter: blur(7px);
-		}
-		100% {
-			opacity: 1;
-			transform: translateY(0);
-			filter: blur(0);
-		}
-	}
+        /* Animaciones reemplazadas por MotionOne */
 </style>

--- a/frontend/src/lib/components/ui/cards/StepCard.svelte
+++ b/frontend/src/lib/components/ui/cards/StepCard.svelte
@@ -15,6 +15,7 @@
 <script lang="ts">
        import { inView } from '$lib/actions/inView';
        import { reducedMotion } from '$lib/stores/reducedMotion';
+       import { Motion } from '@motionone/svelte';
 
        export let stepNumber: number;
        export let title: string;
@@ -26,7 +27,7 @@
 </script>
 
 <!-- *Contenedor -->
-<div
+<Motion.div
         role="region"
         aria-label={`Paso ${stepNumber}: ${title}`}
         class="group relative h-96 transform-gpu overflow-hidden rounded-3xl bg-white
@@ -35,8 +36,8 @@
         class:hover:-translate-y-1={!$reducedMotion}
         class:hover:scale-[1.015]={!$reducedMotion}
         style={`transition-delay:${delay}ms`}
-        class:opacity-0={!animate}
-        class:translate-y-8={!animate}
+        animate={{ opacity: animate ? 1 : 0, translateY: animate ? 0 : 32 }}
+        transition={{ duration: 0.6, delay: delay / 1000 }}
         use:inView={{ onChange: (v) => (animate = v), once: true, threshold: 0.2 }}
 >
 	<!-- *Imagen -->
@@ -93,31 +94,15 @@
 			{details}
 		</p>
 	</div>
-</div>
+</Motion.div>
 
 <style>
-	@keyframes heartbeat {
-		0% {
-			transform: scale(1);
-		}
-		14% {
-			transform: scale(1.16);
-		}
-		28% {
-			transform: scale(1);
-		}
-		42% {
-			transform: scale(1.16);
-		}
-		70% {
-			transform: scale(1);
-		}
-	}
-	.group:hover {
-		box-shadow:
-			0 10px 32px 0 #19318a1a,
-			0 1.5px 10px 0 #e6466611;
-		transform: translateY(-3px) scale(1.02);
-	}
+        /* Animaciones reemplazadas por MotionOne */
+        .group:hover {
+                box-shadow:
+                        0 10px 32px 0 #19318a1a,
+                        0 1.5px 10px 0 #e6466611;
+                transform: translateY(-3px) scale(1.02);
+        }
 </style>
 

--- a/frontend/src/lib/components/ui/elements/Image.svelte
+++ b/frontend/src/lib/components/ui/elements/Image.svelte
@@ -22,57 +22,58 @@
 -->
 
 <script lang="ts">
-	export let src: string = '';
-	export let alt: string = '';
-       export let variant: 'default' | 'circle' | 'card' | 'none' = 'default';
-       export let animate: 'none' | 'heartbeat' | 'zoom' = 'none';
-       export let width: string = '100%';
-       export let height: string = 'auto';
-       export let href: string = '';
-       export let aspectRatio: string = '';
-       // -* Propiedades para imágenes responsivas *-
-       export let srcset: string = '';
-       export let sizes: string = '';
+  import { Motion } from '@motionone/svelte';
+
+  export let src: string = '';
+  export let alt: string = '';
+  export let variant: 'default' | 'circle' | 'card' | 'none' = 'default';
+  export let animate: 'none' | 'heartbeat' | 'zoom' = 'none';
+  export let width: string = '100%';
+  export let height: string = 'auto';
+  export let href: string = '';
+  export let aspectRatio: string = '';
+  // -* Propiedades para imágenes responsivas *-
+  export let srcset: string = '';
+  export let sizes: string = '';
+
+  const heartbeat = {
+    scale: [1, 0.91, 0.98, 0.87, 1],
+    transition: { duration: 1.5, repeat: Infinity }
+  };
 </script>
 
 {#if href}
-	<a {href} class="cursor-pointer">
-                <img
-                        {src}
-                        {alt}
-                        {srcset}
-                        {sizes}
-                        style={`width: ${width}; ${height !== 'auto' ? `height: ${height};` : ''} ${aspectRatio ? `aspect-ratio: ${aspectRatio};` : ''}`}
-			class="
-         block cursor-pointer object-cover
+  <a {href} class="cursor-pointer">
+    <Motion.img
+      {src}
+      {alt}
+      {srcset}
+      {sizes}
+      style={`width: ${width}; ${height !== 'auto' ? `height: ${height};` : ''} ${aspectRatio ? `aspect-ratio: ${aspectRatio};` : ''}`}
+      class="block cursor-pointer object-cover
         {variant === 'default' ? ' rounded-lg shadow-md' : ''}
         {variant === 'circle' ? 'rounded-full' : ''}
-        {variant === 'card' ? 'rounded-xl shadow-sm' : ''}
-        {animate === 'heartbeat' ? 'animate-heartbeat' : ''}
-        {animate === 'zoom' ? 'zoom-on-hover' : ''}
-      "
-			decoding="async"
-			loading="lazy"
-		/>
-	</a>
+        {variant === 'card' ? 'rounded-xl shadow-sm' : ''}"
+      whileHover={animate === 'heartbeat' ? heartbeat : animate === 'zoom' ? { scale: 1.05 } : undefined}
+      decoding="async"
+      loading="lazy"
+    />
+  </a>
 {:else}
-        <img
-                {src}
-                {alt}
-                {srcset}
-                {sizes}
-                style={`width: ${width}; ${height !== 'auto' ? `height: ${height};` : ''} ${aspectRatio ? `aspect-ratio: ${aspectRatio};` : ''}`}
-		class="
-       block object-cover
+  <Motion.img
+    {src}
+    {alt}
+    {srcset}
+    {sizes}
+    style={`width: ${width}; ${height !== 'auto' ? `height: ${height};` : ''} ${aspectRatio ? `aspect-ratio: ${aspectRatio};` : ''}`}
+    class="block object-cover
       {variant === 'default' ? ' rounded-lg shadow-md' : ''}
       {variant === 'circle' ? 'rounded-full' : ''}
-      {variant === 'card' ? 'rounded-xl shadow-sm' : ''}
-      {animate === 'heartbeat' ? 'animate-heartbeat' : ''}
-      {animate === 'zoom' ? 'zoom-on-hover' : ''}
-    "
-		decoding="async"
-		loading="lazy"
-	/>
+      {variant === 'card' ? 'rounded-xl shadow-sm' : ''}"
+    whileHover={animate === 'heartbeat' ? heartbeat : animate === 'zoom' ? { scale: 1.05 } : undefined}
+    decoding="async"
+    loading="lazy"
+  />
 {/if}
 
 <style>
@@ -89,39 +90,5 @@
 		border-radius: 9999px;
 	}
 
-	/* Animación de latido */
-	@keyframes heartbeat {
-		from {
-			transform: scale(1);
-			transform-origin: center center;
-			animation-timing-function: ease-out;
-		}
-		10% {
-			transform: scale(0.91);
-			animation-timing-function: ease-in;
-		}
-		17% {
-			transform: scale(0.98);
-			animation-timing-function: ease-out;
-		}
-		33% {
-			transform: scale(0.87);
-			animation-timing-function: ease-in;
-		}
-		45% {
-			transform: scale(1);
-			animation-timing-function: ease-out;
-		}
-	}
-
-	/* Imágenes con animación de latido */
-	.animate-heartbeat:hover {
-		animation: heartbeat 1.5s ease-in-out infinite both;
-	}
-
-	/* Imágenes con zoom al hacer hover */
-	.zoom-on-hover:hover {
-		transform: scale(1.05);
-		transition: transform 0.3s ease-in-out;
-	}
+        /* Animaciones reemplazadas por MotionOne */
 </style>

--- a/frontend/src/lib/components/ui/navigation/ScrollToTop.svelte
+++ b/frontend/src/lib/components/ui/navigation/ScrollToTop.svelte
@@ -9,8 +9,9 @@
 -->
 
 <script lang="ts">
-	import { onMount } from 'svelte';
-	let isVisible = false;
+  import { onMount } from 'svelte';
+  import { Motion } from '@motionone/svelte';
+  let isVisible = false;
 
 	const handleScroll = () => {
 		isVisible = window.scrollY > 500;
@@ -27,36 +28,33 @@
 	});
 </script>
 
-<button
-	on:click={scrollToTop}
-	aria-label="Volver arriba"
-	class="fixed bottom-7 right-5 z-[120] cursor-pointer rounded-full p-[3px] transition-all duration-700"
-	style="
-		opacity: {isVisible ? 1 : 0};
-		pointer-events: {isVisible ? 'auto' : 'none'};
-		transform: translateY({isVisible ? '0' : '40px'}) scale({isVisible ? 1 : 0.95});
-		transition:
-			opacity 0.5s cubic-bezier(.42,0,.19,1),
-			transform 0.7s cubic-bezier(.39,0,.21,1);
-	"
+<Motion.button
+  on:click={scrollToTop}
+  aria-label="Volver arriba"
+  class="fixed bottom-7 right-5 z-[120] cursor-pointer rounded-full p-[3px]"
+  animate={{ opacity: isVisible ? 1 : 0, translateY: isVisible ? 0 : 40, scale: isVisible ? 1 : 0.95 }}
+  transition={{ duration: 0.7 }}
+  style="pointer-events:{isVisible ? 'auto' : 'none'}"
 >
 	<span
 		class="group flex h-14 w-14 items-center justify-center rounded-full border-2 border-blue-200 bg-gradient-to-br from-white/80 to-blue-100 shadow-xl transition-all
 			duration-500
 			hover:shadow-[0_8px_28px_0_#60a5fa55,0_0_0_6px_#38bdf855]"
 	>
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
-			class="group-hover:animate-bounceUp h-8 w-8 text-blue-500 transition-all duration-500"
-			fill="none"
-			viewBox="0 0 24 24"
-			stroke="currentColor"
-			stroke-width="2"
-		>
+                <Motion.svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="h-8 w-8 text-blue-500"
+                        whileHover={{ y: [-0, -6, 2, 0], scale: [1,1.15,1.08,1] }}
+                        transition={{ duration: 0.5, easing: [.3,1.4,.5,1] }}
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                >
 			<path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7" />
 		</svg>
 	</span>
-</button>
+</Motion.button>
 
 <style>
 	button:hover span,
@@ -73,21 +71,5 @@
 		outline-offset: 3px;
 	}
 
-	@keyframes bounceUp {
-		0% {
-			transform: translateY(0);
-		}
-		30% {
-			transform: translateY(-6px) scale(1.15);
-		}
-		60% {
-			transform: translateY(2px) scale(1.08);
-		}
-		100% {
-			transform: translateY(0);
-		}
-	}
-	.group-hover\:animate-bounceUp:hover {
-		animation: bounceUp 0.5s cubic-bezier(0.3, 1.4, 0.5, 1) 1;
-	}
+        /* Animaciones reemplazadas por MotionOne */
 </style>

--- a/frontend/src/lib/components/visual/Ticker.svelte
+++ b/frontend/src/lib/components/visual/Ticker.svelte
@@ -12,8 +12,9 @@
 -->
 
 <script lang="ts">
-	import clsx from 'clsx';
-	import { onMount } from 'svelte';
+        import clsx from 'clsx';
+        import { onMount } from 'svelte';
+        import { Motion } from '@motionone/svelte';
         export let logos: Array<string | { src: string; href?: string }> = [];
 	let visible = false;
 	let tickerRef: HTMLElement;
@@ -26,19 +27,21 @@
 	});
 </script>
 
-<div
-	bind:this={tickerRef}
-	class="group relative h-20 w-full overflow-hidden
-		transition-all duration-1000"
-	class:ticker-fade-in={visible}
+<Motion.div
+        bind:this={tickerRef}
+        class="group relative h-20 w-full overflow-hidden"
+        animate={{ opacity: visible ? 1 : 0, translateY: visible ? 0 : 32 }}
+        transition={{ duration: 0.9 }}
 >
 	<!-- *Contenedor deslizante -->
-	<div
-		class={clsx(
-			'ticker-track group-hover:pause-animation flex h-full w-max items-center gap-32',
-			customClass
-		)}
-	>
+        <Motion.div
+                class={clsx(
+                        'ticker-track group-hover:pause-animation flex h-full w-max items-center gap-32',
+                        customClass
+                )}
+                animate={{ x: ['0%', '-50%'] }}
+                transition={{ duration: 80, repeat: Infinity, ease: 'linear' }}
+        >
                 {#each Array(6).fill(logos).flat() as logo, i}
                         {#if typeof logo === 'string'}
                                 <img
@@ -67,34 +70,11 @@
                                 {/if}
                         {/if}
                 {/each}
-        </div>
-</div>
+        </Motion.div>
+</Motion.div>
 
 <style>
 	/*Animaciones*/
 
-	.ticker-fade-in {
-		opacity: 1;
-		transform: translateY(0);
-		transition:
-			opacity 0.85s cubic-bezier(0.42, 0, 0.18, 1),
-			transform 0.9s cubic-bezier(0.36, 0, 0.18, 1);
-	}
-	.group:not(.ticker-fade-in) {
-		opacity: 0;
-		transform: translateY(32px);
-	}
-
-	@keyframes ticker-scroll {
-		0% {
-			transform: translateX(0%);
-		}
-		100% {
-			transform: translateX(-50%);
-		}
-	}
-
-	.ticker-track {
-		animation: ticker-scroll 80s linear infinite;
-	}
+        /* Animaciones reemplazadas por MotionOne */
 </style>


### PR DESCRIPTION
## Summary
- use `@motionone/svelte` to animate UI components
- swap old CSS animations in Image, ScrollToTop, Loader, MotionNotice, StepCard, CallToActionSection and Ticker components
- add MotionOne dependency

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0b043a108325bbfd50791bc8d1ac