### PR TITLE
Fix/corregir errores heredados migracion svelte 5

### DIFF
--- a/app/src/lib/components/dashboard/colaborador/EvaluarCierreModal.svelte
+++ b/app/src/lib/components/dashboard/colaborador/EvaluarCierreModal.svelte
@@ -88,7 +88,7 @@
 							</div>
 
 							<a
-								href="/colaborador/proyectos/{proyecto.id}/evaluar-cierre"
+								href={`/colaborador/proyectos/${proyecto.id}/evaluar-cierre`}
 								class="flex items-center gap-2 rounded-xl bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-400 transition-all hover:bg-emerald-500 hover:text-white hover:shadow-lg hover:shadow-emerald-900/40"
 							>
 								Evaluar

--- a/app/src/lib/components/feature/admin/TablaAuditoriaAdmin.svelte
+++ b/app/src/lib/components/feature/admin/TablaAuditoriaAdmin.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Button from '$lib/components/ui/elementos/Button.svelte';
 	import type { RegistroAuditoriaAdminDto } from '$lib/domain/types/dto/PanelAdmin';
 
 	// TODO(Tomás): Agregar más filtros a la bitácora de auditoría.
@@ -26,7 +25,17 @@
 		onCambiarPagina?: (data: { page: number }) => void;
 	}>();
 
-	let innerFiltros = $state({ ...filtros });
+	let innerFiltros = $state<{ idObjeto: string | number; usuarioId: string | number }>({
+		idObjeto: '',
+		usuarioId: ''
+	});
+
+	$effect(() => {
+		innerFiltros = {
+			idObjeto: filtros.idObjeto,
+			usuarioId: filtros.usuarioId
+		};
+	});
 
 	function handleSubmit(e: Event) {
 		e.preventDefault();

--- a/app/src/lib/components/feature/admin/TarjetasMetricasAdmin.svelte
+++ b/app/src/lib/components/feature/admin/TarjetasMetricasAdmin.svelte
@@ -11,9 +11,8 @@
 	} from 'lucide-svelte';
 	import { tweened } from 'svelte/motion';
 	import { cubicOut } from 'svelte/easing';
-	import { onMount } from 'svelte';
 
-	export let kpis: KpisPanelAdminDto;
+	let { kpis } = $props<{ kpis: KpisPanelAdminDto }>();
 
 	// Animaciones para los números principales
 	const tUsuarios = tweened(0, { duration: 2000, easing: cubicOut });
@@ -21,20 +20,12 @@
 	const tReportes = tweened(0, { duration: 2000, easing: cubicOut });
 	const tOnboarding = tweened(0, { duration: 2000, easing: cubicOut });
 
-	onMount(() => {
+	$effect(() => {
 		tUsuarios.set(kpis.totalUsuarios);
 		tProyectos.set(kpis.proyectosEnCurso);
 		tReportes.set(kpis.reportesPendientes);
 		tOnboarding.set(kpis.onboardingPendiente);
 	});
-
-	// Reactividad para cuando cambian los KPIs (ej: filtros)
-	$: {
-		tUsuarios.set(kpis.totalUsuarios);
-		tProyectos.set(kpis.proyectosEnCurso);
-		tReportes.set(kpis.reportesPendientes);
-		tOnboarding.set(kpis.onboardingPendiente);
-	}
 </script>
 
 <!-- KPIs Principales -->

--- a/app/src/lib/components/feature/home/CTASection.svelte
+++ b/app/src/lib/components/feature/home/CTASection.svelte
@@ -9,6 +9,11 @@
 	import Image from '$lib/components/ui/elementos/Image.svelte';
 	import Button from '$lib/components/ui/elementos/Button.svelte';
 
+	let { ctaLabel = 'Registrate y empezá a generar impacto', ctaHref = '/registrarse' } = $props<{
+		ctaLabel?: string;
+		ctaHref?: string;
+	}>();
+
 	let visible = $state(false);
 	let sectionRef: HTMLDivElement | undefined = $state();
 
@@ -68,13 +73,18 @@
 			>
 				<!-- !Button solo visible en mobile -->
 				<div class="sm:hidden">
-					<Button label="Registrate y generá impacto" href="/registro" variant="ghost" size="sm" />
+					<Button
+						label={ctaLabel === 'Mi panel' ? ctaLabel : 'Registrate y generá impacto'}
+						href={ctaHref}
+						variant="ghost"
+						size="sm"
+					/>
 				</div>
 				<!-- !Button solo visible en desktop -->
 				<div class="hidden sm:block">
 					<Button
-						label="Registrate y empezá a generar impacto"
-						href="/registrarse"
+						label={ctaLabel === 'Mi panel' ? ctaLabel : 'Registrate y empezá a generar impacto'}
+						href={ctaHref}
 						variant="ghost"
 						size="md"
 					/>

--- a/app/src/lib/components/feature/home/HeroSection.svelte
+++ b/app/src/lib/components/feature/home/HeroSection.svelte
@@ -4,6 +4,11 @@
 	import Ticker from '$lib/components/ui/Ticker.svelte';
 	import Badge from '$lib/components/ui/elementos/Badge.svelte';
 
+	let { ctaLabel = 'Registrarse', ctaHref = '/registrarse' } = $props<{
+		ctaLabel?: string;
+		ctaHref?: string;
+	}>();
+
 	const logos = [
 		{ src: '/instituciones/rotary.png', href: '/perfil/rotary_arrecifes' },
 		{ src: '/instituciones/unicef.png', href: '/perfil/unicef_argentina' },
@@ -101,8 +106,8 @@
 					class="drop-shadow-lg transition-transform duration-400 hover:scale-105 active:scale-95"
 				>
 					<Button
-						label="Registrarse"
-						href="/registrarse"
+						label={ctaLabel}
+						href={ctaHref}
 						variant="primary"
 						size="md"
 						customClass="px-8 py-3 text-lg font-bold shadow-lg bg-gradient-to-r from-sky-500 to-blue-500 hover:from-sky-400 hover:to-blue-400 mt-3 "

--- a/app/src/lib/components/feature/institucion/CrearProyecto.svelte
+++ b/app/src/lib/components/feature/institucion/CrearProyecto.svelte
@@ -17,7 +17,8 @@
 		MENSAJES_ERROR,
 		validarCalle,
 		validarNumeroCalle,
-		esFechaFutura
+		esFechaFutura,
+		validarUrl
 	} from '$lib/utils/validaciones';
 	import {
 		validarBeneficiariosValor,

--- a/app/src/lib/components/feature/institucion/ObjetivoEvidencias.svelte
+++ b/app/src/lib/components/feature/institucion/ObjetivoEvidencias.svelte
@@ -8,7 +8,8 @@
 		evidenciasEntrada = [],
 		evidenciasSalida = [],
 		totalArchivos = 0,
-		expandido = $bindable(false)
+		expandido = false,
+		onToggle
 	} = $props<{
 		objetivo: any;
 		evidencias?: any[];
@@ -16,10 +17,25 @@
 		evidenciasSalida?: any[];
 		totalArchivos?: number;
 		expandido?: boolean;
+		onToggle?: () => void;
 	}>();
 
+	let expandidoInterno = $state(false);
+	let estaExpandido = $derived(onToggle ? expandido : expandidoInterno);
+
+	$effect(() => {
+		if (!onToggle) {
+			expandidoInterno = expandido;
+		}
+	});
+
 	function toggleExpansion() {
-		expandido = !expandido;
+		if (onToggle) {
+			onToggle();
+			return;
+		}
+
+		expandidoInterno = !expandidoInterno;
 	}
 
 	function obtenerUsername(evidencia: any): string {
@@ -111,7 +127,7 @@
 		</div>
 
 		<svg
-			class="h-5 w-5 text-gray-400 transition-transform {expandido ? 'rotate-180' : ''}"
+			class="h-5 w-5 text-gray-400 transition-transform {estaExpandido ? 'rotate-180' : ''}"
 			fill="none"
 			stroke="currentColor"
 			stroke-width="2"
@@ -121,7 +137,7 @@
 		</svg>
 	</button>
 
-	{#if expandido}
+	{#if estaExpandido}
 		<div class="border-t border-gray-200 bg-white p-4">
 			{#if evidencias.length === 0}
 				<div class="py-4 text-center">

--- a/app/src/lib/components/feature/perfil/PerfilHeader.svelte
+++ b/app/src/lib/components/feature/perfil/PerfilHeader.svelte
@@ -6,6 +6,7 @@
 	import { Pencil, Camera, CheckCircle2 } from 'lucide-svelte';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
+	import { IMAGEN_USUARIO_FALLBACK } from '$lib/utils/util-usuarios';
 
 	type UsuarioCompleto = Usuario | Institucion | Organizacion;
 
@@ -66,9 +67,14 @@
 	<div class="group relative mx-auto shrink-0 md:mx-0" in:fly={{ x: -20, y: 10, duration: 400, easing: cubicOut }}>
 		<div class="relative h-24 w-24 overflow-hidden rounded-2xl bg-white shadow-lg ring-4 ring-white sm:h-28 sm:w-28 md:h-32 md:w-32">
 			<img
-				src={perfilUsuario.url_foto ?? '/logo-1.png'}
+				src={perfilUsuario.url_foto || IMAGEN_USUARIO_FALLBACK}
 				alt="Foto de perfil de {nombreCompleto}"
 				class="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+				onerror={(event) => {
+					const target = event.currentTarget as HTMLImageElement;
+					if (target.src.endsWith(IMAGEN_USUARIO_FALLBACK)) return;
+					target.src = IMAGEN_USUARIO_FALLBACK;
+				}}
 			/>
 			{#if esMiPerfil}
 				<button

--- a/app/src/lib/components/feature/perfil/PerfilSeccionCategorias.svelte
+++ b/app/src/lib/components/feature/perfil/PerfilSeccionCategorias.svelte
@@ -16,13 +16,23 @@
 
 	let categorias = $derived(perfilUsuario.categorias_preferidas || []);
 	let tieneCategorias = $derived(categorias.length > 0);
+	let esInstitucion = $derived(perfilUsuario.rol === 'institucion');
+	let titulo = $derived(
+		esInstitucion
+			? esMiPerfil
+				? 'Mis causas y proyectos frecuentes'
+				: 'Causas y proyectos frecuentes'
+			: esMiPerfil
+				? 'Mis categorías'
+				: 'Categorías'
+	);
 </script>
 
 <section>
 	<div class="mb-4 flex items-center justify-between">
 		<h3 class="flex items-center gap-2 text-sm font-bold text-gray-800">
 			<Tag class="h-4 w-4 text-[#007FFF]" />
-			{esMiPerfil ? 'Mis categorías' : 'Categorías'}
+			{titulo}
 		</h3>
 		{#if esMiPerfil}
 			<button
@@ -56,15 +66,25 @@
 			<div class="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-50 text-gray-400 transition-all duration-300 group-hover:scale-110 group-hover:bg-blue-50 group-hover:text-[#007FFF]">
 				<Tag class="h-7 w-7" />
 			</div>
-			
+
 			<h4 class="mb-1 text-sm font-semibold text-gray-800">
-				{esMiPerfil ? 'Sin categorías personalizadas' : 'No hay categorías definidas'}
+				{esInstitucion
+					? esMiPerfil
+						? 'Sin causas o proyectos frecuentes'
+						: 'No hay causas o proyectos frecuentes definidos'
+					: esMiPerfil
+						? 'Sin categorías personalizadas'
+						: 'No hay categorías definidas'}
 			</h4>
-			
+
 			<p class="max-w-[200px] text-xs leading-relaxed text-gray-500">
-				{esMiPerfil 
-					? 'Agregá las temáticas que más te interesan para personalizar tu experiencia.' 
-					: 'Este usuario aún no ha seleccionado sus categorías de interés.'}
+				{esInstitucion
+					? esMiPerfil
+						? 'Definí las causas que acompañás y los tipos de proyectos que tu institución publica con más frecuencia.'
+						: 'Esta institución todavía no definió las causas o los tipos de proyectos que suele impulsar.'
+					: esMiPerfil
+						? 'Agregá las temáticas que más te interesan para personalizar tu experiencia.'
+						: 'Este usuario aún no ha seleccionado sus categorías de interés.'}
 			</p>
 
 			{#if esMiPerfil}
@@ -73,7 +93,7 @@
 					class="mt-5 inline-flex items-center gap-2 rounded-xl bg-[#007FFF] px-4 py-2 text-xs font-bold text-white shadow-md shadow-blue-200 transition-all duration-200 hover:bg-[#42A1FF] hover:shadow-lg active:scale-95"
 				>
 					<Plus class="h-3.5 w-3.5" />
-					Configurar intereses
+					{esInstitucion ? 'Configurar perfil institucional' : 'Configurar intereses'}
 				</button>
 			{/if}
 		</div>

--- a/app/src/lib/components/feature/perfil/PerfilSeccionTiposParticipacion.svelte
+++ b/app/src/lib/components/feature/perfil/PerfilSeccionTiposParticipacion.svelte
@@ -16,82 +16,113 @@
 
 	let tiposParticipacion = $derived(perfilUsuario.tipos_participacion_preferidas || []);
 	let tieneTipos = $derived(tiposParticipacion.length > 0);
+	let esInstitucion = $derived(perfilUsuario.rol === 'institucion');
+	let titulo = $derived(
+		esInstitucion
+			? esMiPerfil
+				? 'Mis participaciones más alineadas'
+				: 'Participaciones más alineadas'
+			: esMiPerfil
+				? 'Mis formas de participar'
+				: 'Formas de participar'
+	);
+	let estadoVacioTitulo = $derived(
+		esInstitucion
+			? esMiPerfil
+				? 'Sin participaciones frecuentes'
+				: 'No hay participaciones definidas'
+			: esMiPerfil
+				? 'Sin formas de participar'
+				: 'No hay preferencias de participación'
+	);
+	let estadoVacioDescripcion = $derived(
+		esInstitucion
+			? esMiPerfil
+				? 'Definí las formas de participación más alineadas con la misión de tu institución y las que usás con más frecuencia al crear proyectos.'
+				: 'Esta institución aún no definió las formas de participación que más se alinean con su misión.'
+			: esMiPerfil
+				? 'Definí cómo te gustaría colaborar para que podamos recomendarte los mejores proyectos.'
+				: 'Este colaborador aún no ha definido sus formas preferidas de participar.'
+	);
 
 	const coloresChip: Record<string, string> = {
-		'verde':   'border-emerald-100 bg-gradient-to-r from-emerald-50 to-emerald-50/60 text-emerald-700 hover:border-emerald-200 hover:from-emerald-100',
-		'azul':    'border-blue-100 bg-gradient-to-r from-blue-50 to-blue-50/60 text-[#007FFF] hover:border-[#007FFF]/30 hover:from-blue-100',
-		'morado':  'border-purple-100 bg-gradient-to-r from-purple-50 to-purple-50/60 text-purple-700 hover:border-purple-200 hover:from-purple-100',
-		'naranja': 'border-orange-100 bg-gradient-to-r from-orange-50 to-orange-50/60 text-orange-700 hover:border-orange-200 hover:from-orange-100',
-		'rojo':    'border-red-100 bg-gradient-to-r from-red-50 to-red-50/60 text-red-700 hover:border-red-200 hover:from-red-100',
-		'gray':    'border-gray-100 bg-gradient-to-r from-gray-50 to-gray-50/60 text-gray-700 hover:border-gray-200 hover:from-gray-100'
+		verde:
+			'border-emerald-100 bg-gradient-to-r from-emerald-50 to-emerald-50/60 text-emerald-700 hover:border-emerald-200 hover:from-emerald-100',
+		azul:
+			'border-blue-100 bg-gradient-to-r from-blue-50 to-blue-50/60 text-[#007FFF] hover:border-[#007FFF]/30 hover:from-blue-100',
+		morado:
+			'border-purple-100 bg-gradient-to-r from-purple-50 to-purple-50/60 text-purple-700 hover:border-purple-200 hover:from-purple-100',
+		naranja:
+			'border-orange-100 bg-gradient-to-r from-orange-50 to-orange-50/60 text-orange-700 hover:border-orange-200 hover:from-orange-100',
+		rojo:
+			'border-red-100 bg-gradient-to-r from-red-50 to-red-50/60 text-red-700 hover:border-red-200 hover:from-red-100',
+		gray:
+			'border-gray-100 bg-gradient-to-r from-gray-50 to-gray-50/60 text-gray-700 hover:border-gray-200 hover:from-gray-100'
 	};
 
 	function obtenerClaseChip(color: string): string {
-		return coloresChip[color] ?? coloresChip['gray'];
+		return coloresChip[color] ?? coloresChip.gray;
 	}
 </script>
 
-{#if perfilUsuario.rol === 'colaborador'}
-	<section>
-		<div class="mb-4 flex items-center justify-between">
-			<h3 class="flex items-center gap-2 text-sm font-bold text-gray-800">
-				<HandHelping class="h-4 w-4 text-emerald-600" />
-				{esMiPerfil ? 'Mis formas de participar' : 'Formas de participar'}
-			</h3>
+<section>
+	<div class="mb-4 flex items-center justify-between">
+		<h3 class="flex items-center gap-2 text-sm font-bold text-gray-800">
+			<HandHelping class="h-4 w-4 text-emerald-600" />
+			{titulo}
+		</h3>
+		{#if esMiPerfil}
+			<button
+				onclick={onEditarClick}
+				class="inline-flex items-center gap-1.5 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 transition-all duration-200 hover:bg-emerald-100 hover:shadow-sm"
+				aria-label="Editar tipos de participación preferidos"
+			>
+				<Pencil class="h-3 w-3" />
+				Editar
+			</button>
+		{/if}
+	</div>
+
+	{#if tieneTipos}
+		<div class="flex flex-wrap gap-2">
+			{#each tiposParticipacion as tipo, i (tipo.descripcion)}
+				{@const key = tipo.descripcion as keyof typeof INFO_TIPOS_PARTICIPACION}
+				{@const info = INFO_TIPOS_PARTICIPACION[key] ?? { titulo: tipo.descripcion, color: 'gray', icon: null }}
+				<div
+					class="group flex cursor-default items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-all duration-200 hover:shadow-sm {obtenerClaseChip(info.color)}"
+					in:fly={{ y: 8, duration: 250, delay: i * 50, easing: cubicOut }}
+				>
+					{#if info.icon}
+						<Icon
+							src={info.icon}
+							class="h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110"
+						/>
+					{/if}
+					{info.titulo}
+				</div>
+			{/each}
+		</div>
+	{:else}
+		<div class="group flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-white/50 p-8 py-10 text-center transition-all duration-300 hover:border-emerald-200 hover:bg-white hover:shadow-sm">
+			<div class="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-50 text-gray-400 transition-all duration-300 group-hover:scale-110 group-hover:bg-emerald-50 group-hover:text-emerald-600">
+				<HandHelping class="h-7 w-7" />
+			</div>
+
+			<h4 class="mb-1 text-sm font-semibold text-gray-800">{estadoVacioTitulo}</h4>
+
+			<p class="max-w-[200px] text-xs leading-relaxed text-gray-500">
+				{estadoVacioDescripcion}
+			</p>
+
 			{#if esMiPerfil}
 				<button
 					onclick={onEditarClick}
-					class="inline-flex items-center gap-1.5 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-xs font-semibold text-emerald-700 transition-all duration-200 hover:bg-emerald-100 hover:shadow-sm"
-					aria-label="Editar tipos de participación preferidos"
+					class="mt-5 inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-xs font-bold text-white shadow-md shadow-emerald-100 transition-all duration-200 hover:bg-emerald-500 hover:shadow-lg active:scale-95"
 				>
-					<Pencil class="h-3 w-3" />
-					Editar
+					<Plus class="h-3.5 w-3.5" />
+					Configurar participación
 				</button>
 			{/if}
 		</div>
-
-		{#if tieneTipos}
-			<div class="flex flex-wrap gap-2">
-				{#each tiposParticipacion as tipo, i (tipo.descripcion)}
-				{@const key = tipo.descripcion as keyof typeof INFO_TIPOS_PARTICIPACION}
-				{@const info = INFO_TIPOS_PARTICIPACION[key] ?? { titulo: tipo.descripcion, color: 'gray', icon: null }}
-					<div
-						class="group flex cursor-default items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-all duration-200 hover:shadow-sm {obtenerClaseChip(info.color)}"
-						in:fly={{ y: 8, duration: 250, delay: i * 50, easing: cubicOut }}
-					>
-						{#if info.icon}
-							<Icon src={info.icon} class="h-3.5 w-3.5 transition-transform duration-200 group-hover:scale-110" />
-						{/if}
-						{info.titulo}
-					</div>
-				{/each}
-			</div>
-		{:else}
-			<div class="group flex flex-col items-center justify-center rounded-2xl border border-dashed border-gray-200 bg-white/50 p-8 py-10 text-center transition-all duration-300 hover:border-emerald-200 hover:bg-white hover:shadow-sm">
-				<div class="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gray-50 text-gray-400 transition-all duration-300 group-hover:scale-110 group-hover:bg-emerald-50 group-hover:text-emerald-600">
-					<HandHelping class="h-7 w-7" />
-				</div>
-				
-				<h4 class="mb-1 text-sm font-semibold text-gray-800">
-					{esMiPerfil ? 'Sin formas de participar' : 'No hay preferencias de participación'}
-				</h4>
-				
-				<p class="max-w-[200px] text-xs leading-relaxed text-gray-500">
-					{esMiPerfil 
-						? 'Definí cómo te gustaría colaborar para que podamos recomendarte los mejores proyectos.' 
-						: 'Este colaborador aún no ha definido sus formas preferidas de participar.'}
-				</p>
-
-				{#if esMiPerfil}
-					<button
-						onclick={onEditarClick}
-						class="mt-5 inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2 text-xs font-bold text-white shadow-md shadow-emerald-100 transition-all duration-200 hover:bg-emerald-500 hover:shadow-lg active:scale-95"
-					>
-						<Plus class="h-3.5 w-3.5" />
-						Configurar participación
-					</button>
-				{/if}
-			</div>
-		{/if}
-	</section>
-{/if}
+	{/if}
+</section>

--- a/app/src/lib/components/feature/perfil/VistaPerfil.svelte
+++ b/app/src/lib/components/feature/perfil/VistaPerfil.svelte
@@ -489,8 +489,8 @@
 	onActualizarCampo={(c: keyof EditarPerfilForm, v: any) => edicion.actualizarCampo(c, v)}
 	{edicion}
 	{guardando}
-	on:guardar={handleGuardarPerfil}
-	on:cerrar={() => modales.cerrar('edicion')}
+	onGuardar={handleGuardarPerfil}
+	onCerrar={() => modales.cerrar('edicion')}
 />
 
 {#if $modales.resena && !esMiPerfil && $isAuthenticated && $usuarioStore}

--- a/app/src/lib/components/feature/perfil/VistaPerfil.svelte
+++ b/app/src/lib/components/feature/perfil/VistaPerfil.svelte
@@ -376,6 +376,14 @@
 									{esMiPerfil}
 									onEditarClick={abrirModalCategorias}
 								/>
+								{#if perfilUsuario.rol === 'institucion'}
+									<div class="my-5 border-t border-gray-100"></div>
+									<PerfilSeccionTiposParticipacion
+										{perfilUsuario}
+										{esMiPerfil}
+										onEditarClick={abrirModalTiposParticipacion}
+									/>
+								{/if}
 							</div>
 						</div>
 

--- a/app/src/lib/components/feature/proyectos/MisProyectos.svelte
+++ b/app/src/lib/components/feature/proyectos/MisProyectos.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Proyecto } from '$lib/domain/types/Proyecto';
 	import type { Usuario } from '$lib/domain/types/Usuario';
+	import { clsx } from 'clsx';
 	import { Plus, Search } from 'lucide-svelte';
 	import { filtrarProyectosPorUsuario } from '$lib/utils/util-proyectos';
 	import { createProyectosFiltros } from '$lib/stores/proyectosFiltros';
@@ -184,28 +185,34 @@
 	{#snippet headerActionsSnippet()}
 		<div class="mb-4 flex flex-wrap justify-center gap-3">
 			<button
-				class="rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus:ring-2 focus:ring-gray-900/10 focus:outline-none {pestanaActiva ===
-				'todos'
-					? 'bg-blue-600 text-white shadow-sm hover:bg-blue-500'
-					: 'bg-white text-gray-600 ring-1 ring-gray-200 ring-inset hover:bg-gray-50 hover:text-gray-900'}"
+				class={clsx(
+					'rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus:ring-2 focus:ring-gray-900/10 focus:outline-none',
+					pestanaActiva === 'todos'
+						? 'bg-blue-600 text-white shadow-sm hover:bg-blue-500'
+						: 'bg-white text-gray-600 ring-1 ring-gray-200 ring-inset hover:bg-gray-50 hover:text-gray-900'
+				)}
 				onclick={() => cambiarPestana('todos')}
 			>
 				Todos
 			</button>
 			<button
-				class="rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus:ring-2 focus:ring-gray-900/10 focus:outline-none {pestanaActiva ===
-				'activos'
-					? 'bg-blue-600 text-white shadow-sm hover:bg-blue-500'
-					: 'bg-white text-gray-600 ring-1 ring-gray-200 ring-inset hover:bg-gray-50 hover:text-gray-900'}"
+				class={clsx(
+					'rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus:ring-2 focus:ring-gray-900/10 focus:outline-none',
+					pestanaActiva === 'activos'
+						? 'bg-blue-600 text-white shadow-sm hover:bg-blue-500'
+						: 'bg-white text-gray-600 ring-1 ring-gray-200 ring-inset hover:bg-gray-50 hover:text-gray-900'
+				)}
 				onclick={() => cambiarPestana('activos')}
 			>
 				Activos
 			</button>
 			<button
-				class="rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus:ring-2 focus:ring-gray-900/10 focus:outline-none {pestanaActiva ===
-				'completados'
-					? 'bg-blue-600 text-white shadow-sm hover:bg-blue-500'
-					: 'bg-white text-gray-600 ring-1 ring-gray-200 ring-inset hover:bg-gray-50 hover:text-gray-900'}"
+				class={clsx(
+					'rounded-full px-5 py-2 text-sm font-medium transition-all duration-200 focus:ring-2 focus:ring-gray-900/10 focus:outline-none',
+					pestanaActiva === 'completados'
+						? 'bg-blue-600 text-white shadow-sm hover:bg-blue-500'
+						: 'bg-white text-gray-600 ring-1 ring-gray-200 ring-inset hover:bg-gray-50 hover:text-gray-900'
+				)}
 				onclick={() => cambiarPestana('completados')}
 			>
 				Completados

--- a/app/src/lib/components/feature/proyectos/ProyectoHeader.svelte
+++ b/app/src/lib/components/feature/proyectos/ProyectoHeader.svelte
@@ -10,7 +10,12 @@
 	import { haReportado, limpiarReporteLog } from '$lib/utils/util-reportes';
 	import { usuario } from '$lib/stores/auth';
 
-	let { proyecto, esAdministrador = false, esCreador = false, tieneReportePendiente = false } = $props<{
+	let {
+		proyecto,
+		esAdministrador = false,
+		esCreador = false,
+		tieneReportePendiente = false
+	} = $props<{
 		proyecto: Proyecto;
 		esAdministrador?: boolean;
 		esCreador?: boolean;
@@ -19,7 +24,6 @@
 
 	let mostrarMenuReportar = $state(false);
 
-	// Sincronizar log local con SSR: si el SSR dice que no hay pendiente, limpiamos el log local.
 	$effect(() => {
 		if ($usuario && proyecto?.id_proyecto && tieneReportePendiente === false) {
 			limpiarReporteLog($usuario.id_usuario!, 'Proyecto', proyecto.id_proyecto!);
@@ -57,7 +61,6 @@
 
 	<div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent"></div>
 
-	<!-- Menú de más acciones -->
 	{#if $usuario && !esCreador && !esAdministrador}
 		<div class="absolute top-4 right-4 z-10">
 			<div class="relative" use:clickOutside={() => (mostrarMenuReportar = false)}>
@@ -124,7 +127,7 @@
 			{#if proyecto.institucion?.nombre_legal}
 				{#if obtenerUrlPerfil(proyecto.institucion)}
 					<a
-						href={obtenerUrlPerfil(proyecto.institucion)}
+						href={`${obtenerUrlPerfil(proyecto.institucion)}?from=proyecto&proyecto=${proyecto.id_proyecto}`}
 						class="text-lg font-medium text-white/90 transition-colors hover:text-white hover:underline"
 					>
 						{proyecto.institucion.nombre_legal}

--- a/app/src/lib/components/feature/proyectos/ProyectoProgreso.svelte
+++ b/app/src/lib/components/feature/proyectos/ProyectoProgreso.svelte
@@ -172,7 +172,7 @@
 
 <ModalCalculoAportes 
 	bind:show={showModal} 
-	progresoObjetivos={progresoCantidad}
+	progresoCantidad={progresoCantidad}
 	{progresoTiempo}
 	{progresoTotal}
 />

--- a/app/src/lib/components/feature/registro/PreferenciasForm.svelte
+++ b/app/src/lib/components/feature/registro/PreferenciasForm.svelte
@@ -4,6 +4,7 @@
 	import { Check } from 'lucide-svelte';
 
 	interface Props {
+		rol?: 'institucion' | 'colaborador' | null;
 		categorias?: { id_categoria: number; descripcion: string }[];
 		tiposParticipacion?: { id_tipo_participacion: number; descripcion: string }[];
 		procesando?: boolean;
@@ -12,6 +13,7 @@
 	}
 
 	let {
+		rol = null,
 		categorias = [],
 		tiposParticipacion = [],
 		procesando = false,
@@ -22,6 +24,24 @@
 	let categoriasSeleccionadas = $state<number[]>([]);
 	let tiposSeleccionados = $state<number[]>([]);
 	let animarEntrada = $state(false);
+
+	let esInstitucion = $derived(rol === 'institucion');
+	let tituloCategorias = $derived(
+		esInstitucion ? 'Causas y tipos de proyectos frecuentes' : 'Causas que te mueven'
+	);
+	let descripcionCategorias = $derived(
+		esInstitucion
+			? 'Seleccioná las categorías que mejor representan los proyectos que tu institución suele publicar y las causas que acompaña con más frecuencia.'
+			: 'Seleccioná una o más categorías de interés.'
+	);
+	let tituloTipos = $derived(
+		esInstitucion ? 'Formas de participación más alineadas' : '¿Cómo te gustaría ayudar?'
+	);
+	let descripcionTipos = $derived(
+		esInstitucion
+			? 'Marcá las formas de participación más alineadas con la misión de tu institución y las que probablemente vas a usar con más frecuencia al crear proyectos.'
+			: 'Indicanos tus preferencias de participación.'
+	);
 
 	$effect(() => {
 		const timer = setTimeout(() => (animarEntrada = true), 100);
@@ -62,11 +82,11 @@
 		animarEntrada ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'
 	)}
 >
-	<div class="space-y-8 rounded-3xl bg-white p-6 shadow-sm border border-slate-100 md:p-10">
+	<div class="space-y-8 rounded-3xl border border-slate-100 bg-white p-6 shadow-sm md:p-10">
 		<section class="space-y-6">
 			<header>
-				<h3 class="text-lg font-semibold text-slate-800">Causas que te mueven</h3>
-				<p class="text-xs text-slate-500">Seleccioná una o más categorías de interés.</p>
+				<h3 class="text-lg font-semibold text-slate-800">{tituloCategorias}</h3>
+				<p class="text-xs text-slate-500">{descripcionCategorias}</p>
 			</header>
 			<div class="flex flex-wrap gap-3">
 				{#each categorias as categoria (categoria.id_categoria)}
@@ -94,8 +114,8 @@
 
 		<section class="space-y-6">
 			<header>
-				<h3 class="text-lg font-semibold text-slate-800 text-left">¿Cómo te gustaría ayudar?</h3>
-				<p class="text-xs text-slate-500 text-left">Indicanos tus preferencias de participación.</p>
+				<h3 class="text-left text-lg font-semibold text-slate-800">{tituloTipos}</h3>
+				<p class="text-left text-xs text-slate-500">{descripcionTipos}</p>
 			</header>
 			<div class="flex flex-wrap gap-3">
 				{#each tiposParticipacion as tipo (tipo.id_tipo_participacion)}
@@ -132,7 +152,7 @@
 				label={procesando ? 'Guardando...' : 'Finalizar registro'}
 				onclick={finalizar}
 				disabled={procesando}
-				customClass="w-full sm:w-auto min-w-[120px]"
+				customClass="w-full min-w-[120px] sm:w-auto"
 			/>
 		</div>
 	</div>

--- a/app/src/lib/components/layout/Footer.svelte
+++ b/app/src/lib/components/layout/Footer.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
+	import { afterNavigate } from '$app/navigation';
+
 	let visible = $state(false);
 	let hasAnimated = $state(false);
 	let footerRef: HTMLElement | undefined;
 	const anio = new Date().getFullYear();
+
+	afterNavigate(() => {
+		visible = true;
+		hasAnimated = true;
+	});
 
 	$effect(() => {
 		const obs = new IntersectionObserver(

--- a/app/src/lib/components/layout/Header.svelte
+++ b/app/src/lib/components/layout/Header.svelte
@@ -2,7 +2,7 @@
 	import Button from '$lib/components/ui/elementos/Button.svelte';
 	import Image from '$lib/components/ui/elementos/Image.svelte';
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import {
 		isAuthenticated,
 		usuario as usuarioStore,
@@ -33,7 +33,7 @@
 	let { proyectos = [] }: { proyectos?: Proyecto[] } = $props();
 
 	let menuAbierto = $state(false);
-	let visible = $state(false);
+	let visible = $state(true);
 	let mostrarHeader = $state(true);
 	let lastScrollY = $state(0);
 	let headerRef = $state<HTMLElement | undefined>();
@@ -115,6 +115,14 @@
 		}
 		lastScrollY = current;
 	};
+
+	afterNavigate(() => {
+		mostrarHeader = true;
+		menuAbierto = false;
+		mostrarDropdown = false;
+		visible = true;
+		layoutStore.setHeaderVisible(true);
+	});
 
 	$effect(() => {
 		if (!headerRef) return;

--- a/app/src/lib/components/layout/Header.svelte
+++ b/app/src/lib/components/layout/Header.svelte
@@ -13,7 +13,6 @@
 		isInstitucionVerificada
 	} from '$lib/stores/auth';
 	import { layoutStore } from '$lib/stores/layout';
-	import type { Proyecto } from '$lib/domain/types/Proyecto';
 	import {
 		MessageCircle,
 		ChevronDown,
@@ -29,8 +28,6 @@
 	} from 'lucide-svelte';
 
 	import { obtenerNombreCompleto } from '$lib/utils/util-usuarios';
-
-	let { proyectos = [] }: { proyectos?: Proyecto[] } = $props();
 
 	let menuAbierto = $state(false);
 	let visible = $state(true);
@@ -57,16 +54,6 @@
 	}
 
 	const verificacionAprobada = $derived($isInstitucionVerificada);
-
-	const proyectosEnCursoCount = $derived(
-		$usuarioStore
-			? proyectos.filter(
-					(p) => p.institucion_id === $usuarioStore?.id_usuario && p.estado === 'en_curso'
-				).length
-			: 0
-	);
-
-	const limiteProyectosAlcanzado = $derived(proyectosEnCursoCount >= 5);
 
 	const emailUsuario = $derived(
 		$usuarioStore?.contactos?.find((c) => c.tipo_contacto === 'email' && c.etiqueta === 'principal')
@@ -250,7 +237,7 @@
 							<!-- Acciones Principales -->
 							<div class="p-1">
 								{#if $isInstitucion}
-									{#if verificacionAprobada && !limiteProyectosAlcanzado}
+									{#if verificacionAprobada}
 										<a
 											href="/proyectos/crear"
 											class="group flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-200 hover:bg-blue-500/20 hover:text-white"
@@ -262,9 +249,7 @@
 									{:else}
 										<div
 											class="flex w-full cursor-not-allowed items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-500 opacity-60"
-											title={!verificacionAprobada
-												? 'Debés tener la verificación aprobada'
-												: 'Límite de proyectos alcanzado'}
+											title="Debés tener la verificación aprobada"
 										>
 											<PlusCircle class="h-4 w-4" />
 											Crear proyecto

--- a/app/src/lib/components/layout/Header.svelte
+++ b/app/src/lib/components/layout/Header.svelte
@@ -27,7 +27,7 @@
 		FileWarning
 	} from 'lucide-svelte';
 
-	import { obtenerNombreCompleto } from '$lib/utils/util-usuarios';
+	import { obtenerNombreCompleto, IMAGEN_USUARIO_FALLBACK } from '$lib/utils/util-usuarios';
 
 	let menuAbierto = $state(false);
 	let visible = $state(true);
@@ -206,9 +206,14 @@
 					>
 						<div class="h-8 w-8 overflow-hidden rounded-full border-2 border-blue-400/60">
 							<img
-								src={$usuarioStore?.url_foto ?? '/users/escuela-esperanza.jpg'}
+								src={$usuarioStore?.url_foto || IMAGEN_USUARIO_FALLBACK}
 								alt="Avatar"
 								class="h-full w-full object-cover"
+								onerror={(event) => {
+									const target = event.currentTarget as HTMLImageElement;
+									if (target.src.endsWith(IMAGEN_USUARIO_FALLBACK)) return;
+									target.src = IMAGEN_USUARIO_FALLBACK;
+								}}
 							/>
 						</div>
 						<div class="hidden flex-col items-start leading-none md:flex">
@@ -360,9 +365,14 @@
 					<!-- Perfil Mobile -->
 					<div class="mb-4 flex items-center gap-3 rounded-xl bg-blue-500/5 p-3">
 						<img
-							src={$usuarioStore?.url_foto ?? '/users/escuela-esperanza.jpg'}
+							src={$usuarioStore?.url_foto || IMAGEN_USUARIO_FALLBACK}
 							alt="Avatar"
 							class="h-10 w-10 rounded-full object-cover"
+							onerror={(event) => {
+								const target = event.currentTarget as HTMLImageElement;
+								if (target.src.endsWith(IMAGEN_USUARIO_FALLBACK)) return;
+								target.src = IMAGEN_USUARIO_FALLBACK;
+							}}
 						/>
 						<div class="flex flex-col">
 							<span class="font-medium text-white">{nombreCompleto}</span>

--- a/app/src/lib/components/ui/cards/ProyectoCard.svelte
+++ b/app/src/lib/components/ui/cards/ProyectoCard.svelte
@@ -5,6 +5,12 @@
 	import { Icon } from '@steeze-ui/svelte-icon';
 	const usuarioPorDefecto = '/users/user-default.png';
 
+	function aplicarFallbackImagen(event: Event) {
+		const target = event.currentTarget as HTMLImageElement;
+		if (target.src.endsWith(usuarioPorDefecto)) return;
+		target.src = usuarioPorDefecto;
+	}
+
 	import {
 		getUbicacionCorta,
 		formatearFechaBadge,
@@ -119,6 +125,7 @@
 							alt="Tu perfil"
 							class="h-full w-full object-cover"
 							loading="lazy"
+							onerror={aplicarFallbackImagen}
 						/>
 					</div>
 				{/if}
@@ -170,6 +177,7 @@
 							alt={proyecto.institucion.nombre_legal}
 							class="h-5 w-5 rounded-full object-cover shadow-sm"
 							loading="lazy"
+							onerror={aplicarFallbackImagen}
 						/>
 						<span class="truncate font-medium text-gray-700">
 							{proyecto.institucion.nombre_legal}

--- a/app/src/lib/components/ui/cards/ResenaCard.svelte
+++ b/app/src/lib/components/ui/cards/ResenaCard.svelte
@@ -9,6 +9,7 @@
 		Administrador
 	} from '$lib/domain/types/Usuario';
 	import { obtenerColorRol } from '$lib/utils/util-ui';
+	import { IMAGEN_USUARIO_FALLBACK } from '$lib/utils/util-usuarios';
 
 	type UsuarioCompleto = Usuario | Institucion | Organizacion | Unipersonal | Administrador;
 
@@ -106,9 +107,14 @@
 			<a href="/perfil/{resena.username}" class="group flex items-center gap-3">
 				{#if autor?.url_foto}
 					<img
-						src={autor.url_foto}
+						src={autor.url_foto || IMAGEN_USUARIO_FALLBACK}
 						alt={nombreMostrar}
 						class="h-8 w-8 rounded-full object-cover ring-2 ring-gray-100 transition-all group-hover:ring-blue-100"
+						onerror={(event) => {
+							const target = event.currentTarget as HTMLImageElement;
+							if (target.src.endsWith(IMAGEN_USUARIO_FALLBACK)) return;
+							target.src = IMAGEN_USUARIO_FALLBACK;
+						}}
 					/>
 				{:else}
 					<div

--- a/app/src/lib/components/ui/forms/DireccionForm.svelte
+++ b/app/src/lib/components/ui/forms/DireccionForm.svelte
@@ -4,7 +4,7 @@
 	import Button from '$lib/components/ui/elementos/Button.svelte';
 	import Select from '$lib/components/ui/elementos/Select.svelte';
 
-	import { MENSAJES_ERROR } from '$lib/utils/validaciones';
+	import { MENSAJES_ERROR, validarUrl } from '$lib/utils/validaciones';
 	import { construirUrlsVistaPreviaGoogleMaps } from '$lib/utils/googleMaps';
 
 	import type { Provincia } from '$lib/domain/entities/Provincia';
@@ -143,7 +143,11 @@
 		localidad:
 			localidad?.id_provincia === provincia?.id_provincia
 				? ''
-				: MENSAJES_ERROR.ciudadNoPerteneceProvincia
+				: MENSAJES_ERROR.ciudadNoPerteneceProvincia,
+		url_google_maps:
+			requiereGeolocalizacion && editandoUrlMapaGoogle && urlGoogleMaps.trim() && !validarUrl(urlGoogleMaps)
+				? MENSAJES_ERROR.urlInvalida
+				: ''
 	});
 
 	let tieneErrores = $derived(Object.values(errores).some((mensajeError) => mensajeError !== ''));
@@ -178,7 +182,7 @@
 		toastStore.show({
 			variant: 'info',
 			title: 'Paso omitido',
-			message: 'Podés completar tu ubicación más adelante desde el panel de la institución.'
+			message: 'Podés completar tu ubicación más adelante desde tu panel.'
 		});
 		onskip?.();
 	}
@@ -235,6 +239,7 @@
 						<Input
 							id="urlGoogleMaps"
 							bind:value={urlGoogleMaps}
+							error={intentoEnvio ? errores.url_google_maps : ''}
 							placeholder="Se genera automáticamente"
 							customClass="w-full rounded-2xl border border-gray-300 bg-white px-4 py-2 text-base text-black placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-100"
 						/>
@@ -243,13 +248,13 @@
 							href={urlGoogleMaps}
 							target="_blank"
 							rel="noopener noreferrer"
-							class="block w-full rounded-2xl border border-transparent bg-blue-50 px-4 py-3 text-base text-blue-700 underline transition-colors duration-200 hover:bg-blue-100 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none"
+							class="block w-full rounded-2xl border border-transparent bg-blue-50 px-4 py-3 pr-14 text-base text-blue-700 underline transition-colors duration-200 hover:bg-blue-100 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none"
 						>
 							{urlGoogleMapsLegible}
 						</a>
 					{:else}
 						<p
-							class="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-base text-gray-500 italic"
+							class="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-4 py-3 pr-14 text-base text-gray-500 italic"
 						>
 							Se genera automáticamente
 						</p>
@@ -286,6 +291,9 @@
 						{/if}
 					</button>
 				</div>
+				{#if intentoEnvio && errores.url_google_maps}
+					<p class="mt-2 text-sm text-red-600">{errores.url_google_maps}</p>
+				{/if}
 			</div>
 
 			{#if googleMapsPreview && !editandoUrlMapaGoogle}

--- a/app/src/lib/components/ui/forms/MetodosContactoForm.svelte
+++ b/app/src/lib/components/ui/forms/MetodosContactoForm.svelte
@@ -221,7 +221,7 @@
 							id={'valor-' + i}
 							bind:value={contacto.valor}
 							placeholder={getPlaceholder(contacto.tipo_contacto)}
-							error={contacto.valor.trim() ? errors[i] : ''}
+							error={intentoEnvio || camposTocados[i]?.valor ? errors[i] : ''}
 							onblur={() => marcarCampoComoTocado(i, 'valor')}
 							disabled={i === 0 && bloquearPrimerContacto}
 						/>
@@ -250,6 +250,7 @@
 								id={'etiqueta-' + i}
 								bind:value={contacto.etiqueta}
 								placeholder="Ej: Telegram..."
+								error={intentoEnvio || camposTocados[i]?.etiqueta ? errors[i] : ''}
 								onblur={() => marcarCampoComoTocado(i, 'etiqueta')}
 							/>
 						{:else}

--- a/app/src/lib/components/ui/forms/ReporteForm.svelte
+++ b/app/src/lib/components/ui/forms/ReporteForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { MotivoReporte } from '$lib/domain/types/Reporte';
+	import { clsx } from 'clsx';
 	import Button from '$lib/components/ui/elementos/Button.svelte';
 
 	let {
@@ -146,9 +147,12 @@
 			id="motivo"
 			bind:value={motivo}
 			disabled={isLoading}
-			class="mt-2 w-full rounded-lg border px-4 py-2.5 text-gray-900 shadow-sm transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 {errorMotivo
-				? 'border-red-300 focus:border-red-500 focus:ring-red-200'
-				: 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'}"
+			class={clsx(
+				'mt-2 w-full rounded-lg border px-4 py-2.5 text-gray-900 shadow-sm transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+				errorMotivo
+					? 'border-red-300 focus:border-red-500 focus:ring-red-200'
+					: 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'
+			)}
 		>
 			<option value="">-- Seleccioná un motivo --</option>
 			{#each motivosDisponibles as motivoOpcion}
@@ -182,9 +186,12 @@
 				bind:value={motivoOtro}
 				disabled={isLoading}
 				placeholder="Detalle su motivo..."
-				class="mt-2 w-full rounded-lg border px-4 py-2.5 text-gray-900 shadow-sm transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 {errorMotivoOtro
-					? 'border-red-300 focus:border-red-500 focus:ring-red-200'
-					: 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'}"
+				class={clsx(
+					'mt-2 w-full rounded-lg border px-4 py-2.5 text-gray-900 shadow-sm transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+					errorMotivoOtro
+						? 'border-red-300 focus:border-red-500 focus:ring-red-200'
+						: 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'
+				)}
 			/>
 			{#if errorMotivoOtro}
 				<p class="mt-2 flex items-center gap-1 text-sm text-red-600">
@@ -220,9 +227,12 @@
 			disabled={isLoading}
 			maxlength="800"
 			placeholder="Describí en detalle la irregularidad observada. Incluí fechas, nombres, montos o cualquier evidencia que ayude a la investigación..."
-			class="mt-2 w-full resize-none rounded-lg border px-4 py-3 text-gray-900 shadow-sm transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 {errorDescripcion
-				? 'border-red-300 focus:border-red-500 focus:ring-red-200'
-				: 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'}"
+			class={clsx(
+				'mt-2 w-full resize-none rounded-lg border px-4 py-3 text-gray-900 shadow-sm transition focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+				errorDescripcion
+					? 'border-red-300 focus:border-red-500 focus:ring-red-200'
+					: 'border-gray-300 focus:border-blue-500 focus:ring-blue-200'
+			)}
 		></textarea>
 		{#if errorDescripcion}
 			<p class="mt-2 flex items-center gap-1 text-sm text-red-600">
@@ -237,11 +247,14 @@
 			</p>
 		{/if}
 		<p
-			class="mt-2 text-xs transition-colors duration-200 {descripcion.length < 20
-				? 'text-amber-600'
-				: descripcion.length > 800
-					? 'text-red-600'
-					: 'text-gray-500'}"
+			class={clsx(
+				'mt-2 text-xs transition-colors duration-200',
+				descripcion.length < 20
+					? 'text-amber-600'
+					: descripcion.length > 800
+						? 'text-red-600'
+						: 'text-gray-500'
+			)}
 		>
 			Mínimo 20 caracteres • Máximo 800 • Caracteres: {descripcion.length}
 		</p>

--- a/app/src/lib/components/ui/modals/ModalEditarPerfil.svelte
+++ b/app/src/lib/components/ui/modals/ModalEditarPerfil.svelte
@@ -5,7 +5,6 @@
 	import MetodosContactoForm from '$lib/components/ui/forms/MetodosContactoForm.svelte';
 	import Button from '$lib/components/ui/elementos/Button.svelte';
 	import { toastStore } from '$lib/stores/toast';
-	import { createEventDispatcher } from 'svelte';
 	import { env } from '$lib/infrastructure/config/env';
 
 	let provincias = $state<Provincia[]>([]);
@@ -172,17 +171,17 @@
 		onActualizarDescripcion,
 		onActualizarCampo,
 		edicion,
-		guardando = false
+		guardando = false,
+		onGuardar = () => {},
+		onCerrar = () => {}
 	} = $props();
 
-	const dispatch = createEventDispatcher();
-
 	function handleSubmit() {
-		dispatch('guardar');
+		onGuardar();
 	}
 
 	function handleCerrar() {
-		dispatch('cerrar');
+		onCerrar();
 	}
 
 	$effect(() => {

--- a/app/src/lib/domain/entities/Archivo.ts
+++ b/app/src/lib/domain/entities/Archivo.ts
@@ -9,6 +9,11 @@ export class Archivo {
 	usuario_id?: number | null;
 	evidencia_id?: number | null;
 	proyecto_id?: number | null;
+	usuario?: {
+		nombre?: string | null;
+		apellido?: string | null;
+		username?: string | null;
+	} | null;
 
 	constructor(data: Partial<Archivo>) {
 		Object.assign(this, data);

--- a/app/src/lib/domain/use-cases/evaluacion/RegistrarEvaluacion.ts
+++ b/app/src/lib/domain/use-cases/evaluacion/RegistrarEvaluacion.ts
@@ -38,7 +38,16 @@ export class RegistrarEvaluacion {
         const existente = await this.evaluacionRepo.findBySolicitudAndColaborador(params.solicitudId, params.colaboradorId);
         if (existente) throw new Error('Ya has enviado tu evaluación para esta solicitud.');
 
-        // 4. Crear Evaluación
+        // 4. Validar que la solicitud corresponda al proyecto evaluado y siga pendiente
+        const solicitud = await this.solicitudRepo.findByProyectoId(params.proyectoId);
+        if (!solicitud || solicitud.id_solicitud !== params.solicitudId) {
+            throw new Error('La solicitud no corresponde al proyecto indicado.');
+        }
+        if (solicitud.estado !== 'pendiente') {
+            throw new Error('La solicitud ya no está pendiente de evaluación.');
+        }
+
+        // 5. Crear Evaluación
         const nuevaEvaluacion = new Evaluacion({
             solicitud_id: params.solicitudId,
             colaborador_id: params.colaboradorId,
@@ -60,7 +69,7 @@ export class RegistrarEvaluacion {
             usuario_id: params.colaboradorId
         });
 
-        // 5. Lógica de consenso y umbral
+        // 6. Lógica de consenso y umbral
         if (params.voto === 'rechazado') {
             // Caso rechazo:
             const rechazosPrevios = await this.proyectoRepo.countSolicitudesRechazadas(params.proyectoId)

--- a/app/src/lib/infrastructure/config/breadcrumbs.config.ts
+++ b/app/src/lib/infrastructure/config/breadcrumbs.config.ts
@@ -1,13 +1,6 @@
-/**
- * * DECISIÓN DE DISEÑO
- *    -*- Configuración centralizada de las rutas con Breadcrumbs.
- *    -*- Permite habilitarlas sin alterar la lógica del store.
- */
-
 export const ENABLED_BREADCRUMB_PATHS = [
 	// Público
 	'/proyectos/:id',
-	'/perfil/:username',
 
 	// Proyectos
 	'/proyectos/:id/editar',
@@ -31,9 +24,30 @@ export const ENABLED_BREADCRUMB_PATHS = [
 /**
  * -!- Verifica si la ruta actual está habilitada para mostrar Breadcrumbs.
  */
-export function shouldShowBreadcrumbs(pathname: string): boolean {
-	const normalized = pathname.replace(/\/+$/, '') || '/';
+export function shouldShowBreadcrumbs(input: string | URL): boolean {
+	const url = typeof input === 'string' ? new URL(input, 'http://breadcrumbs.local') : input;
+	const normalized = url.pathname.replace(/\/+$/, '') || '/';
+
+	if (matchRoute(normalized, '/perfil/:username')) {
+		return hasProfileBreadcrumbContext(url);
+	}
+
 	return ENABLED_BREADCRUMB_PATHS.some((pattern) => matchRoute(normalized, pattern));
+}
+
+export function hasProfileBreadcrumbContext(url: URL): boolean {
+	const from = url.searchParams.get('from');
+	const proyectoId = url.searchParams.get('proyecto');
+
+	if (from === 'proyecto') {
+		return Boolean(proyectoId);
+	}
+
+	if (from === 'solicitudes') {
+		return true;
+	}
+
+	return false;
 }
 
 // * Utilidad interna para comparar rutas con segmentos dinámicos

--- a/app/src/lib/infrastructure/prisma/client.ts
+++ b/app/src/lib/infrastructure/prisma/client.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from '@prisma/client';
 import { Pool } from 'pg';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { env } from '$env/dynamic/private';
@@ -20,3 +20,20 @@ const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
 export const prisma = globalForPrisma.prisma || new PrismaClient({ adapter });
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export type PrismaDbClient = PrismaClient | Prisma.TransactionClient;
+
+export function esClientePrisma(db: PrismaDbClient): db is PrismaClient {
+	return '$transaction' in db;
+}
+
+export async function ejecutarEnTransaccionExistenteOTotal<T>(
+	db: PrismaDbClient,
+	callback: (tx: Prisma.TransactionClient) => Promise<T>
+): Promise<T> {
+	if (esClientePrisma(db)) {
+		return db.$transaction(callback);
+	}
+
+	return callback(db);
+}

--- a/app/src/lib/infrastructure/supabase/postgres/colaboracion.repo.ts
+++ b/app/src/lib/infrastructure/supabase/postgres/colaboracion.repo.ts
@@ -1,9 +1,11 @@
 import type { ColaboracionRepository } from '$lib/domain/repositories/ColaboracionRepository';
 import { Colaboracion } from '$lib/domain/entities/Colaboracion';
-import { prisma } from '$lib/infrastructure/prisma/client';
+import { type PrismaDbClient, prisma } from '$lib/infrastructure/prisma/client';
 import { ColaboracionMapper } from './mappers/colaboracion.mapper';
 
 export class PostgresColaboracionRepository implements ColaboracionRepository {
+	constructor(private readonly db: PrismaDbClient = prisma) {}
+
 	private includeOptions = {
 		colaborador: {
 			include: {
@@ -35,7 +37,7 @@ export class PostgresColaboracionRepository implements ColaboracionRepository {
 
 	async findByProyecto(proyectoId: number): Promise<Colaboracion[]> {
 		try {
-			const colaboraciones = await prisma.colaboracion.findMany({
+			const colaboraciones = await this.db.colaboracion.findMany({
 				where: { proyecto_id: proyectoId },
 				include: this.includeOptions,
 				orderBy: { created_at: 'desc' }
@@ -68,7 +70,7 @@ export class PostgresColaboracionRepository implements ColaboracionRepository {
 		colaboradorId: number
 	): Promise<Colaboracion | null> {
 		try {
-			const colaboracion = await prisma.colaboracion.findFirst({
+			const colaboracion = await this.db.colaboracion.findFirst({
 				where: {
 					proyecto_id: proyectoId,
 					colaborador_id: colaboradorId

--- a/app/src/lib/infrastructure/supabase/postgres/evaluacion.repo.ts
+++ b/app/src/lib/infrastructure/supabase/postgres/evaluacion.repo.ts
@@ -1,12 +1,14 @@
-import { prisma } from '$lib/infrastructure/prisma/client';
+import { type PrismaDbClient, prisma } from '$lib/infrastructure/prisma/client';
 import type { EvaluacionRepository } from '$lib/domain/repositories/EvaluacionRepository';
 import type { Evaluacion } from '$lib/domain/entities/Evaluacion';
 import { EvaluacionMapper } from '$lib/infrastructure/supabase/postgres/mappers/evaluacion.mapper';
 
 export class PostgresEvaluacionRepository implements EvaluacionRepository {
+    constructor(private readonly db: PrismaDbClient = prisma) {}
+
     async create(evaluacion: Evaluacion): Promise<Evaluacion> {
         const data = EvaluacionMapper.toPrisma(evaluacion);
-        const created = await prisma.evaluacion.create({
+        const created = await this.db.evaluacion.create({
             data: {
                 ...data,
             },
@@ -16,7 +18,7 @@ export class PostgresEvaluacionRepository implements EvaluacionRepository {
     }
 
     async findBySolicitudAndColaborador(solicitudId: number, colaboradorId: number): Promise<Evaluacion | null> {
-        const found = await prisma.evaluacion.findUnique({
+        const found = await this.db.evaluacion.findUnique({
             where: {
                 solicitud_id_colaborador_id: {
                     solicitud_id: solicitudId,
@@ -29,7 +31,7 @@ export class PostgresEvaluacionRepository implements EvaluacionRepository {
     }
 
     async countVotosBySolicitud(solicitudId: number): Promise<{ aprobados: number; rechazados: number; total: number }> {
-        const counts = await prisma.evaluacion.groupBy({
+        const counts = await this.db.evaluacion.groupBy({
             by: ['voto'],
             where: { solicitud_id: solicitudId },
             _count: { voto: true }

--- a/app/src/lib/infrastructure/supabase/postgres/evidencia.repo.ts
+++ b/app/src/lib/infrastructure/supabase/postgres/evidencia.repo.ts
@@ -1,9 +1,11 @@
-import { prisma } from '$lib/infrastructure/prisma/client';
+import { type PrismaDbClient, prisma } from '$lib/infrastructure/prisma/client';
 import type { EvidenciaRepository } from '../../../domain/repositories/EvidenciaRepository';
 import { Evidencia } from '../../../domain/entities/Evidencia';
 import { Archivo } from '../../../domain/entities/Archivo';
 
 export class PostgresEvidenciaRepository implements EvidenciaRepository {
+	constructor(private readonly db: PrismaDbClient = prisma) {}
+
 	async create(evidencia: Evidencia): Promise<Evidencia> {
 		if (!evidencia.archivos || evidencia.archivos.length === 0) {
 			throw new Error('No se puede crear una evidencia sin archivos.');
@@ -172,7 +174,7 @@ export class PostgresEvidenciaRepository implements EvidenciaRepository {
 	}
 
 	async findAllByProyecto(proyectoId: number): Promise<Evidencia[]> {
-		const evidencias = await prisma.evidencia.findMany({
+		const evidencias = await this.db.evidencia.findMany({
 			where: {
 				participacion_permitida: {
 					id_proyecto: proyectoId

--- a/app/src/lib/infrastructure/supabase/postgres/historial-cambios.repo.ts
+++ b/app/src/lib/infrastructure/supabase/postgres/historial-cambios.repo.ts
@@ -1,4 +1,4 @@
-import { prisma } from '$lib/infrastructure/prisma/client';
+import { type PrismaDbClient, prisma } from '$lib/infrastructure/prisma/client';
 import { Prisma } from '@prisma/client';
 import type {
 	HistorialDeCambiosRepository,
@@ -7,6 +7,8 @@ import type {
 import type { HistorialDeCambios } from '$lib/domain/types/HistorialDeCambios';
 
 export class PostgresHistorialDeCambiosRepository implements HistorialDeCambiosRepository {
+	constructor(private readonly db: PrismaDbClient = prisma) {}
+
 	private mapear(c: {
 		id_cambio: number;
 		tipo_objeto: string;
@@ -34,7 +36,7 @@ export class PostgresHistorialDeCambiosRepository implements HistorialDeCambiosR
 	}
 
 	async create(cambio: HistorialDeCambios, tx?: unknown): Promise<HistorialDeCambios> {
-		const db = (tx as Prisma.TransactionClient) || prisma;
+		const db = (tx as Prisma.TransactionClient) || this.db;
 
 		const created = await db.historialDeCambios.create({
 			data: {

--- a/app/src/lib/infrastructure/supabase/postgres/proyecto.repo.ts
+++ b/app/src/lib/infrastructure/supabase/postgres/proyecto.repo.ts
@@ -3,7 +3,7 @@ import type { Proyecto } from '$lib/domain/entities/Proyecto';
 import type { EstadoDescripcion } from '$lib/domain/types/Estado';
 import type { HistorialDeCambios } from '$lib/domain/types/HistorialDeCambios';
 import type { TipoParticipacionDescripcion } from '$lib/domain/types/TipoParticipacion';
-import { prisma } from '$lib/infrastructure/prisma/client';
+import { esClientePrisma, type PrismaDbClient, prisma } from '$lib/infrastructure/prisma/client';
 import { ProyectoMapper } from './mappers/proyecto.mapper';
 import { ProyectoCategoriaRepoPrisma } from './proyecto-categoria.repo';
 import { PostgresCategoriaRepository } from './categoria.repo';
@@ -12,6 +12,8 @@ import type { ProyectoSearchCriteria } from '$lib/domain/types/dto/ProyectoSearc
 import { analizarProyecto } from '$lib/domain/use-cases/analizarProyecto';
 
 export class PostgresProyectoRepository implements ProyectoRepository {
+	constructor(private readonly db: PrismaDbClient = prisma) {}
+
 	private includeOptions = {
 		estado: true,
 		proyecto_categorias: {
@@ -213,7 +215,7 @@ export class PostgresProyectoRepository implements ProyectoRepository {
 	}
 
 	async findById(id: number): Promise<Proyecto | null> {
-		const proyecto = await prisma.proyecto.findUnique({
+		const proyecto = await this.db.proyecto.findUnique({
 			where: { id_proyecto: id },
 			include: this.includeOptions
 		});
@@ -580,13 +582,13 @@ export class PostgresProyectoRepository implements ProyectoRepository {
 
 	async updateEstado(id: number, nuevoEstado: EstadoDescripcion): Promise<Proyecto> {
 		// Buscar el ID del estado basado en la descripción
-		const estadoObj = await prisma.estado.findUnique({
+		const estadoObj = await this.db.estado.findUnique({
 			where: { descripcion: nuevoEstado }
 		});
 
 		if (!estadoObj) throw new Error(`Estado ${nuevoEstado} no encontrado`);
 
-		const updated = await prisma.proyecto.update({
+		const updated = await this.db.proyecto.update({
 			where: { id_proyecto: id },
 			data: {
 				estado_id: estadoObj.id_estado
@@ -595,7 +597,7 @@ export class PostgresProyectoRepository implements ProyectoRepository {
 		});
 
 		// Generación de resumen y aprendizajes (asíncrono)
-		if (nuevoEstado === 'completado') {
+		if (nuevoEstado === 'completado' && esClientePrisma(this.db)) {
 			setTimeout(async () => {
 				try {
 					const result = await analizarProyecto(id);
@@ -642,7 +644,7 @@ export class PostgresProyectoRepository implements ProyectoRepository {
 	}
 
 	async countSolicitudesRechazadas(id: number): Promise<number> {
-		return await prisma.solicitudFinalizacion.count({
+		return await this.db.solicitudFinalizacion.count({
 			where: {
 				proyecto_id: id,
 				estado: 'rechazada'

--- a/app/src/lib/infrastructure/supabase/postgres/solicitud-finalizacion.repo.ts
+++ b/app/src/lib/infrastructure/supabase/postgres/solicitud-finalizacion.repo.ts
@@ -1,4 +1,8 @@
-import { prisma } from '$lib/infrastructure/prisma/client';
+import {
+	ejecutarEnTransaccionExistenteOTotal,
+	type PrismaDbClient,
+	prisma
+} from '$lib/infrastructure/prisma/client';
 import type { SolicitudFinalizacionRepository } from '$lib/domain/repositories/SolicitudFinalizacionRepository';
 import type { SolicitudFinalizacion } from '$lib/domain/types/SolicitudFinalizacion';
 
@@ -7,8 +11,10 @@ const archivoInclude = { include: { usuario: true } } as const;
 export class PostgresSolicitudFinalizacionRepository
 	implements SolicitudFinalizacionRepository
 {
+	constructor(private readonly db: PrismaDbClient = prisma) {}
+
 	async findByProyectoId(proyectoId: number): Promise<SolicitudFinalizacion | null> {
-		const solicitud = await prisma.solicitudFinalizacion.findFirst({
+		const solicitud = await this.db.solicitudFinalizacion.findFirst({
 			where: {
 				proyecto_id: proyectoId
 			},
@@ -37,7 +43,7 @@ export class PostgresSolicitudFinalizacionRepository
 	}
 
 	async findRechazadasByProyectoId(proyectoId: number): Promise<SolicitudFinalizacion[]> {
-		const solicitudes = await prisma.solicitudFinalizacion.findMany({
+		const solicitudes = await this.db.solicitudFinalizacion.findMany({
 			where: {
 				proyecto_id: proyectoId,
 				estado: 'rechazada'
@@ -67,7 +73,7 @@ export class PostgresSolicitudFinalizacionRepository
 		estado: string,
 		_motivoRechazo?: string
 	): Promise<SolicitudFinalizacion> {
-		const updated = await prisma.solicitudFinalizacion.update({
+		const updated = await this.db.solicitudFinalizacion.update({
 			where: { id_solicitud: id },
 			data: {
 				estado
@@ -92,7 +98,7 @@ export class PostgresSolicitudFinalizacionRepository
 	}
 
 	async countRechazadasByProyectoId(proyectoId: number): Promise<number> {
-		const count = await prisma.solicitudFinalizacion.count({
+		const count = await this.db.solicitudFinalizacion.count({
 			where: {
 				proyecto_id: proyectoId,
 				estado: 'rechazada'
@@ -111,7 +117,7 @@ export class PostgresSolicitudFinalizacionRepository
 			throw new Error('La solicitud de finalización debe incluir al menos una evidencia.');
 		}
 
-		const created = await prisma.$transaction(async (tx) => {
+		const created = await ejecutarEnTransaccionExistenteOTotal(this.db, async (tx) => {
 			const nuevaSolicitud = await tx.solicitudFinalizacion.create({
 				data: {
 					proyecto_id: solicitud.proyecto_id,

--- a/app/src/lib/stores/auth.ts
+++ b/app/src/lib/stores/auth.ts
@@ -80,6 +80,21 @@ export const isInstitucionVerificada = derived(authStore, ($auth) =>
 	esInstitucionVerificada($auth.usuario)
 );
 
+export function syncAuthState(usuario: UsuarioCompleto | null): void {
+	if (usuario) {
+		authStore.update((state) => ({
+			...state,
+			usuario,
+			isAuthenticated: true,
+			isLoading: false,
+			error: null
+		}));
+		return;
+	}
+
+	authStore.set(unauthenticatedState);
+}
+
 export const authActions = {
 	/**
 	 * Iniciar sesión (acepta email o username como "identificador")

--- a/app/src/lib/stores/breadcrumbs.ts
+++ b/app/src/lib/stores/breadcrumbs.ts
@@ -2,22 +2,15 @@ import { writable, derived, get } from 'svelte/store';
 import { page } from '$app/stores';
 import { shouldShowBreadcrumbs } from '$lib/infrastructure/config/breadcrumbs.config';
 
-// * DECISIÓN DE DISEÑO
-// -*- Fuente única de verdad para las migas de pan.
-// -*- Genera las rutas sólo en páginas habilitadas y permite reemplazarlas manualmente.
-// -*- Ignora los intentos de establecer migas si la ruta no está habilitada.
-
 export interface BreadcrumbItem {
 	label: string;
-	href?: string; // Si no tiene href, es el item actual (no clickeable)
+	href?: string;
 }
 
-// * Migas definidas manualmente
 const custom = writable<BreadcrumbItem[] | null>(null);
 
-// * Migas automáticas derivadas de la ruta
 const auto = derived(page, ($page) => {
-	if (!shouldShowBreadcrumbs($page.url.pathname)) return [];
+	if (!shouldShowBreadcrumbs($page.url)) return [];
 
 	const segments = $page.url.pathname.split('/').filter(Boolean);
 	let path = '';
@@ -36,24 +29,21 @@ const auto = derived(page, ($page) => {
 	return items.length >= 2 ? items : [];
 });
 
-// * Migas en uso (manuales o automáticas) según la ruta actual
 export const breadcrumbs = derived([page, auto, custom], ([$page, $auto, $custom]) => {
-	if (!shouldShowBreadcrumbs($page.url.pathname)) return [];
+	if (!shouldShowBreadcrumbs($page.url)) return [];
 	if ($custom && $custom.length) return $custom;
 	return $auto;
 });
 
-// Función para establecer breadcrumbs manuales
 export function setBreadcrumbs(items: BreadcrumbItem[]) {
-	const currentPath = get(page).url.pathname;
-	if (shouldShowBreadcrumbs(currentPath)) {
+	const currentUrl = get(page).url;
+	if (shouldShowBreadcrumbs(currentUrl)) {
 		custom.set(items);
 	} else {
 		custom.set(null);
 	}
 }
 
-// Limpia las migas personalizadas
 export function clearBreadcrumbs() {
 	custom.set(null);
 }

--- a/app/src/lib/utils/util-usuarios.ts
+++ b/app/src/lib/utils/util-usuarios.ts
@@ -1,6 +1,8 @@
 // import { mockUsuarios } from '$lib/infrastructure/mocks/mock-usuarios';
 import type { Usuario, Institucion } from '$lib/domain/types/Usuario';
 
+export const IMAGEN_USUARIO_FALLBACK = '/users/user-default.png';
+
 /**
  * Obtiene el nombre completo de un usuario por su ID
  * @param usuarioId - ID del usuario
@@ -29,6 +31,19 @@ export function obtenerNombreCompleto(usuario: Usuario): string {
 	}
 
 	return `${u.nombre} ${u.apellido}`.trim() || u.username;
+}
+
+export function obtenerRutaPanelPorRol(rol: Usuario['rol'] | undefined): string {
+	switch (rol) {
+		case 'institucion':
+			return '/institucion/mi-panel';
+		case 'colaborador':
+			return '/colaborador/mi-panel';
+		case 'administrador':
+			return '/admin';
+		default:
+			return '/';
+	}
 }
 
 /**

--- a/app/src/routes/(protected)/admin/+page.svelte
+++ b/app/src/routes/(protected)/admin/+page.svelte
@@ -15,12 +15,29 @@
 	);
 	let loading = $state(false);
 
-	let kpis = $state(data.kpis);
-	let onboarding = $state(data.onboarding);
-	let usuarios = $state(data.usuarios);
-	let reportes = $state(data.reportes);
-	let logs = $state(data.logs);
-	let auditoriaPaginacion = $state(data.auditoriaPaginacion);
+	let kpisOverride = $state<PageData['kpis'] | null>(null);
+	let onboardingOverride = $state<PageData['onboarding'] | null>(null);
+	let usuariosOverride = $state<PageData['usuarios'] | null>(null);
+	let reportesOverride = $state<PageData['reportes'] | null>(null);
+	let logsOverride = $state<PageData['logs'] | null>(null);
+	let auditoriaPaginacionOverride = $state<PageData['auditoriaPaginacion'] | null>(null);
+
+	let kpis = $derived(kpisOverride ?? data.kpis);
+	let onboarding = $derived(onboardingOverride ?? data.onboarding);
+	let usuarios = $derived(usuariosOverride ?? data.usuarios);
+	let reportes = $derived(reportesOverride ?? data.reportes);
+	let logs = $derived(logsOverride ?? data.logs);
+	let auditoriaPaginacion = $derived(auditoriaPaginacionOverride ?? data.auditoriaPaginacion);
+
+	$effect(() => {
+		data;
+		kpisOverride = null;
+		onboardingOverride = null;
+		usuariosOverride = null;
+		reportesOverride = null;
+		logsOverride = null;
+		auditoriaPaginacionOverride = null;
+	});
 
 	let filtrosUsuarios = $state({
 		rol: '',
@@ -43,12 +60,12 @@
 
 	async function refreshDashboard() {
 		const res = await fetch('/api/admin/dashboard');
-		if (res.ok) kpis = await res.json();
+		if (res.ok) kpisOverride = await res.json();
 	}
 
 	async function refreshOnboarding() {
 		const res = await fetch('/api/admin/onboarding');
-		if (res.ok) onboarding = await res.json();
+		if (res.ok) onboardingOverride = await res.json();
 	}
 
 	async function refreshUsuarios() {
@@ -57,12 +74,12 @@
 		if (filtrosUsuarios.estado) query.set('estado', filtrosUsuarios.estado);
 		if (filtrosUsuarios.fechaAltaDesde) query.set('fechaAltaDesde', filtrosUsuarios.fechaAltaDesde);
 		const res = await fetch(`/api/admin/usuarios?${query.toString()}`);
-		if (res.ok) usuarios = await res.json();
+		if (res.ok) usuariosOverride = await res.json();
 	}
 
 	async function refreshReportes() {
 		const res = await fetch('/api/admin/reportes');
-		if (res.ok) reportes = await res.json();
+		if (res.ok) reportesOverride = await res.json();
 	}
 
 	async function onAprobarOnboarding(detail: { idVerificacion: number }) {
@@ -186,8 +203,8 @@
 			const res = await fetch(`/api/admin/auditoria?${query.toString()}`);
 			const body = await res.json().catch(() => null);
 			if (!res.ok) throw new Error(body?.error || 'No se pudo consultar auditoría');
-			logs = body.items;
-			auditoriaPaginacion = {
+			logsOverride = body.items;
+			auditoriaPaginacionOverride = {
 				total: body.total,
 				page: body.page,
 				pageSize: body.pageSize

--- a/app/src/routes/(protected)/admin/parametros/+page.svelte
+++ b/app/src/routes/(protected)/admin/parametros/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { preventDefault } from 'svelte/legacy';
-
 	import type { PageData } from './$types';
 	import { invalidateAll } from '$app/navigation';
 
@@ -22,6 +20,11 @@
 	function cancelEditing() {
 		editingId = null;
 		editValue = '';
+	}
+
+	async function handleSubmitParametro(event: SubmitEvent, id: number) {
+		event.preventDefault();
+		await saveParametro(id);
 	}
 
 	async function saveParametro(id: number) {
@@ -83,7 +86,7 @@
 							{#if editingId === parametro.id_parametro}
 								<form
 									class="flex gap-2"
-									onsubmit={preventDefault(() => saveParametro(parametro.id_parametro))}
+									onsubmit={(event) => handleSubmitParametro(event, parametro.id_parametro)}
 								>
 									<input
 										type="text"

--- a/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.server.ts
+++ b/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.server.ts
@@ -6,6 +6,7 @@ import { PostgresEvaluacionRepository } from '$lib/infrastructure/supabase/postg
 import { PostgresSolicitudFinalizacionRepository } from '$lib/infrastructure/supabase/postgres/solicitud-finalizacion.repo';
 import { PostgresHistorialDeCambiosRepository } from '$lib/infrastructure/supabase/postgres/historial-cambios.repo';
 import { RegistrarEvaluacion } from '$lib/domain/use-cases/evaluacion/RegistrarEvaluacion';
+import { prisma } from '$lib/infrastructure/prisma/client';
 
 const proyectoRepo = new PostgresProyectoRepository();
 const colaboracionRepo = new PostgresColaboracionRepository();
@@ -30,26 +31,172 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	const user = locals.usuario!; // Garantizado por AuthGuard en hooks
 
 	const proyectoId = Number(params.id);
+	if (!Number.isFinite(proyectoId) || proyectoId <= 0) {
+		throw redirect(303, '/proyectos');
+	}
 
-	// 1. Verificar que el colaborador tenga una colaboración APROBADA en este proyecto
-	const colaboraciones = await colaboracionRepo.findByProyecto(proyectoId);
-	const esColaboradorAprobado = colaboraciones.some(
-		(c) => c.colaborador_id === user.id_usuario && c.estado === 'aprobada'
-	);
+	const [proyectoRow, colaboracionAprobada, totalColaboradores, solicitudRow] = await Promise.all([
+		prisma.proyecto.findUnique({
+			where: { id_proyecto: proyectoId },
+			select: {
+				id_proyecto: true,
+				titulo: true,
+				beneficiarios: true,
+				estado: {
+					select: {
+						descripcion: true
+					}
+				},
+				participacion_permitida: {
+					select: {
+						id_participacion_permitida: true,
+						id_proyecto: true,
+						id_tipo_participacion: true,
+						objetivo: true,
+						unidad_medida: true,
+						especie: true,
+						tipo_participacion: {
+							select: {
+								id_tipo_participacion: true,
+								descripcion: true
+							}
+						},
+						colaboraciones_tipo_participacion: {
+							select: {
+								cantidad: true
+							}
+						}
+					}
+				}
+			}
+		}),
+		prisma.colaboracion.findFirst({
+			where: {
+				proyecto_id: proyectoId,
+				colaborador_id: user.id_usuario!,
+				estado: 'aprobada'
+			},
+			select: {
+				id_colaboracion: true
+			}
+		}),
+		prisma.colaboracion.count({
+			where: {
+				proyecto_id: proyectoId,
+				estado: 'aprobada'
+			}
+		}),
+		prisma.solicitudFinalizacion.findFirst({
+			where: {
+				proyecto_id: proyectoId
+			},
+			orderBy: {
+				created_at: 'desc'
+			},
+			select: {
+				id_solicitud: true,
+				proyecto_id: true,
+				estado: true,
+				created_at: true,
+				solicitud_evidencias: {
+					select: {
+						evidencia: {
+							select: {
+								id_evidencia: true,
+								tipo_evidencia: true,
+								created_at: true,
+								id_participacion_permitida: true,
+								archivos: {
+									select: {
+										id_archivo: true,
+										nombre_original: true,
+										url: true,
+										descripcion: true,
+										tipo_mime: true,
+										tamanio_bytes: true,
+										created_at: true,
+										usuario: {
+											select: {
+												nombre: true,
+												apellido: true,
+												username: true
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		})
+	]);
 
-	if (!esColaboradorAprobado) {
+	if (!proyectoRow) throw redirect(303, '/proyectos');
+
+	if (!colaboracionAprobada) {
 		throw redirect(303, `/proyectos/${proyectoId}`);
 	}
 
-	// 2. Verificar proyecto
-	const proyecto = await proyectoRepo.findById(proyectoId);
-	if (!proyecto) throw redirect(303, '/proyectos');
+	const proyecto = {
+		id_proyecto: proyectoRow.id_proyecto,
+		titulo: proyectoRow.titulo,
+		beneficiarios: proyectoRow.beneficiarios ? Number(proyectoRow.beneficiarios) : null,
+		estado: proyectoRow.estado?.descripcion ?? null,
+		participacion_permitida: proyectoRow.participacion_permitida.map((participacion) => ({
+			id_participacion_permitida: participacion.id_participacion_permitida,
+			id_proyecto: participacion.id_proyecto,
+			id_tipo_participacion: participacion.id_tipo_participacion,
+			objetivo: Number(participacion.objetivo),
+			actual: participacion.colaboraciones_tipo_participacion.reduce(
+				(total, colaboracion) => total + Number(colaboracion.cantidad || 0),
+				0
+			),
+			unidad_medida: participacion.unidad_medida ?? undefined,
+			especie: participacion.especie ?? undefined,
+			tipo_participacion: participacion.tipo_participacion
+				? {
+						id_tipo_participacion: participacion.tipo_participacion.id_tipo_participacion,
+						descripcion: participacion.tipo_participacion.descripcion
+					}
+				: undefined
+		}))
+	};
 
-	// 3. Buscar Solicitud más reciente del proyecto
-	const solicitud = await solicitudRepo.findByProyectoId(proyectoId);
-
-	// Para el frontend
-	const evidencias = solicitud?.evidencias ?? [];
+	const solicitud = solicitudRow
+		? {
+				id_solicitud: solicitudRow.id_solicitud,
+				proyecto_id: solicitudRow.proyecto_id,
+				estado: solicitudRow.estado ?? undefined,
+				created_at: solicitudRow.created_at ?? undefined,
+				evidencia_ids: solicitudRow.solicitud_evidencias.map(
+					({ evidencia }) => evidencia.id_evidencia
+				),
+				evidencias: solicitudRow.solicitud_evidencias.map(({ evidencia }) => ({
+					id_evidencia: evidencia.id_evidencia,
+					tipo_evidencia: evidencia.tipo_evidencia,
+					created_at: evidencia.created_at ?? undefined,
+					id_participacion_permitida: evidencia.id_participacion_permitida,
+					archivos_ids: evidencia.archivos.map((archivo) => archivo.id_archivo),
+					archivos: evidencia.archivos.map((archivo) => ({
+						id_archivo: archivo.id_archivo,
+						nombre_original: archivo.nombre_original,
+						url: archivo.url,
+						descripcion: archivo.descripcion,
+						tipo_mime: archivo.tipo_mime,
+						tamanio_bytes: archivo.tamanio_bytes ? Number(archivo.tamanio_bytes) : null,
+						created_at: archivo.created_at ?? undefined,
+						usuario: archivo.usuario
+							? {
+									nombre: archivo.usuario.nombre,
+									apellido: archivo.usuario.apellido,
+									username: archivo.usuario.username
+								}
+							: undefined
+					}))
+				}))
+			}
+		: null;
 
 	// Si no hay solicitud y el proyecto está en revisión, es un estado inconsistente o
 	// la solicitud se borró manualmente. Manejar con cuidado.
@@ -57,24 +204,21 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		// Log error interno
 	}
 
-	// 4. Buscar Evaluación del usuario actual
-	let evaluacionUsuario = null;
-	if (solicitud && solicitud.id_solicitud !== undefined && user.id_usuario !== undefined) {
-		evaluacionUsuario = await evaluacionRepo.findBySolicitudAndColaborador(
-			solicitud.id_solicitud!,
-			user.id_usuario!
-		);
-	}
-
-	// 5. Contadores
-	const totalColaboradores = colaboraciones.filter((c) => c.estado === 'aprobada').length;
-	const votosRealizados = solicitud
-		? (await evaluacionRepo.countVotosBySolicitud(solicitud.id_solicitud!)).total
-		: 0;
+	const [evaluacionUsuario, votosRealizados] =
+		solicitud && solicitud.id_solicitud !== undefined && user.id_usuario !== undefined
+			? await Promise.all([
+					evaluacionRepo.findBySolicitudAndColaborador(solicitud.id_solicitud, user.id_usuario),
+					prisma.evaluacion.count({
+						where: {
+							solicitud_id: solicitud.id_solicitud
+						}
+					})
+				])
+			: [null, 0];
 
 	return {
 		proyecto: JSON.parse(JSON.stringify(proyecto)),
-		solicitud: JSON.parse(JSON.stringify({ ...solicitud, evidencias })),
+		solicitud: solicitud ? JSON.parse(JSON.stringify(solicitud)) : null,
 		evaluacion: evaluacionUsuario ? JSON.parse(JSON.stringify(evaluacionUsuario)) : null,
 		yaVote: !!evaluacionUsuario,
 		totalColaboradores,

--- a/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.server.ts
+++ b/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.server.ts
@@ -6,7 +6,9 @@ import { PostgresEvaluacionRepository } from '$lib/infrastructure/supabase/postg
 import { PostgresSolicitudFinalizacionRepository } from '$lib/infrastructure/supabase/postgres/solicitud-finalizacion.repo';
 import { PostgresHistorialDeCambiosRepository } from '$lib/infrastructure/supabase/postgres/historial-cambios.repo';
 import { RegistrarEvaluacion } from '$lib/domain/use-cases/evaluacion/RegistrarEvaluacion';
+import { analizarProyecto } from '$lib/domain/use-cases/analizarProyecto';
 import { prisma } from '$lib/infrastructure/prisma/client';
+import { Prisma } from '@prisma/client';
 
 const proyectoRepo = new PostgresProyectoRepository();
 const colaboracionRepo = new PostgresColaboracionRepository();
@@ -14,13 +16,18 @@ const evaluacionRepo = new PostgresEvaluacionRepository();
 const solicitudRepo = new PostgresSolicitudFinalizacionRepository();
 const historialRepo = new PostgresHistorialDeCambiosRepository();
 
-const registrarEvaluacion = new RegistrarEvaluacion(
-	evaluacionRepo,
-	proyectoRepo,
-	colaboracionRepo,
-	solicitudRepo,
-	historialRepo
-);
+function dispararAnalisisProyectoCompletado(proyectoId: number) {
+	setTimeout(async () => {
+		try {
+			const result = await analizarProyecto(proyectoId);
+			if (!result.success && result.error) {
+				console.error(`[IA] Error en análisis del proyecto ${proyectoId}:`, result.error);
+			}
+		} catch (error) {
+			console.error(`[IA] Excepción no controlada en background task del proyecto ${proyectoId}:`, error);
+		}
+	}, 0);
+}
 
 /**
  * Evaluación de solicitudes de cierre por parte del colaborador.
@@ -88,7 +95,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		}),
 		prisma.solicitudFinalizacion.findFirst({
 			where: {
-				proyecto_id: proyectoId
+				proyecto_id: proyectoId,
+				estado: 'pendiente'
 			},
 			orderBy: {
 				created_at: 'desc'
@@ -240,15 +248,51 @@ export const actions: Actions = {
 		if (!solicitudId) return fail(400, { error: 'Falta ID de solicitud' });
 
 		try {
-			await registrarEvaluacion.execute({
-				proyectoId,
-				solicitudId,
-				colaboradorId: user.id_usuario!,
-				voto: 'aprobado',
-				justificacion
+			await prisma.$transaction(
+				async (tx) => {
+					const registrarEvaluacion = new RegistrarEvaluacion(
+						new PostgresEvaluacionRepository(tx),
+						new PostgresProyectoRepository(tx),
+						new PostgresColaboracionRepository(tx),
+						new PostgresSolicitudFinalizacionRepository(tx),
+						new PostgresHistorialDeCambiosRepository(tx)
+					);
+
+					await registrarEvaluacion.execute({
+						proyectoId,
+						solicitudId,
+						colaboradorId: user.id_usuario!,
+						voto: 'aprobado',
+						justificacion
+					});
+				},
+				{
+					isolationLevel: Prisma.TransactionIsolationLevel.Serializable
+				}
+			);
+
+			const proyectoActualizado = await prisma.proyecto.findUnique({
+				where: { id_proyecto: proyectoId },
+				select: {
+					estado: {
+						select: {
+							descripcion: true
+						}
+					}
+				}
 			});
 
-			return { success: true };
+			if (proyectoActualizado?.estado?.descripcion === 'completado') {
+				dispararAnalisisProyectoCompletado(proyectoId);
+			}
+
+			return {
+				success: true,
+				message:
+					proyectoActualizado?.estado?.descripcion === 'completado'
+						? 'Tu voto fue registrado. El proyecto quedó completado.'
+						: 'Tu voto fue registrado correctamente.'
+			};
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Error interno';
 			return fail(400, { error: errorMessage });
@@ -269,15 +313,47 @@ export const actions: Actions = {
 			return fail(400, { error: 'La justificación es obligatoria para rechazar' });
 
 		try {
-			await registrarEvaluacion.execute({
-				proyectoId,
-				solicitudId,
-				colaboradorId: user.id_usuario!,
-				voto: 'rechazado',
-				justificacion
+			await prisma.$transaction(
+				async (tx) => {
+					const registrarEvaluacion = new RegistrarEvaluacion(
+						new PostgresEvaluacionRepository(tx),
+						new PostgresProyectoRepository(tx),
+						new PostgresColaboracionRepository(tx),
+						new PostgresSolicitudFinalizacionRepository(tx),
+						new PostgresHistorialDeCambiosRepository(tx)
+					);
+
+					await registrarEvaluacion.execute({
+						proyectoId,
+						solicitudId,
+						colaboradorId: user.id_usuario!,
+						voto: 'rechazado',
+						justificacion
+					});
+				},
+				{
+					isolationLevel: Prisma.TransactionIsolationLevel.Serializable
+				}
+			);
+
+			const proyectoActualizado = await prisma.proyecto.findUnique({
+				where: { id_proyecto: proyectoId },
+				select: {
+					estado: {
+						select: {
+							descripcion: true
+						}
+					}
+				}
 			});
 
-			return { success: true };
+			return {
+				success: true,
+				message:
+					proyectoActualizado?.estado?.descripcion === 'en_auditoria'
+						? 'Tu rechazo fue registrado. El proyecto pasó a auditoría.'
+						: 'Tu rechazo fue registrado. El proyecto volvió a pendiente de solicitud de cierre.'
+			};
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : 'Error interno';
 			return fail(400, { error: errorMessage });

--- a/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.svelte
+++ b/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.svelte
@@ -66,6 +66,16 @@
 		data.proyecto.participacion_permitida ?? [],
 		(data.solicitud as any)?.evidencias ?? []
 	));
+
+	function estaExpandido(objetivoId: number | null | undefined): boolean {
+		if (objetivoId == null) return false;
+		return objetivosExpandidos[objetivoId] ?? false;
+	}
+
+	function toggleObjetivo(objetivoId: number | null | undefined) {
+		if (objetivoId == null) return;
+		objetivosExpandidos[objetivoId] = !estaExpandido(objetivoId);
+	}
 </script>
 
 <svelte:head>
@@ -77,7 +87,7 @@
 		<!-- Header -->
 		<nav class="mb-4 flex items-center text-sm text-slate-500">
 			<a
-				href="/proyectos/{data.proyecto.id_proyecto}"
+				href={`/proyectos/${data.proyecto.id_proyecto}`}
 				class="flex items-center transition-colors hover:text-blue-600"
 			>
 				<ChevronLeft class="mr-1 h-4 w-4" />
@@ -100,7 +110,7 @@
 				</p>
 				<div class="mt-8">
 					<a
-						href="/proyectos/{data.proyecto.id_proyecto}"
+						href={`/proyectos/${data.proyecto.id_proyecto}`}
 						class="inline-flex items-center rounded-xl border border-transparent bg-blue-600 px-6 py-3 text-base font-medium text-white shadow-md transition-all hover:bg-blue-700 hover:shadow-lg"
 					>
 						Volver al panel
@@ -196,7 +206,8 @@
 											{evidenciasEntrada}
 											{evidenciasSalida}
 											{totalArchivos}
-											bind:expandido={objetivosExpandidos[objetivo.id_participacion_permitida!]}
+											expandido={estaExpandido(objetivo.id_participacion_permitida)}
+											onToggle={() => toggleObjetivo(objetivo.id_participacion_permitida)}
 										/>
 									{/each}
 								</div>

--- a/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.svelte
+++ b/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
 	import { enhance } from '$app/forms';
 	import { invalidateAll } from '$app/navigation';
 	import { fade, fly } from 'svelte/transition';
@@ -34,7 +32,7 @@
 	let evaluacion = $derived(data.evaluacion);
 	let yaVote = $derived(data.yaVote);
 
-	run(() => {
+	$effect(() => {
 		if (proyecto) {
 			setBreadcrumbs([
 				BREADCRUMB_ROUTES.proyectos,

--- a/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.svelte
+++ b/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.svelte
@@ -52,6 +52,41 @@
 
 	const MIN_CARACTERES_JUSTIFICACION = 20;
 
+	async function manejarResultadoVotacion(
+		result: {
+			type: 'success' | 'failure' | 'error' | 'redirect';
+			data?: { message?: string; error?: string };
+		},
+		update: (options?: { reset?: boolean; invalidateAll?: boolean }) => Promise<void>,
+		fallbackSuccess: string,
+		opciones?: { cerrarModalRechazo?: boolean }
+	) {
+		if (result.type === 'success') {
+			toastStore.show({
+				message: String(result.data?.message ?? fallbackSuccess),
+				variant: 'success'
+			});
+			await update({ reset: true, invalidateAll: true });
+
+			if (opciones?.cerrarModalRechazo) {
+				showRejectModal = false;
+				justificacionRechazo = '';
+			}
+
+			loading = false;
+			return;
+		}
+
+		if (result.type === 'failure' && result.data?.error) {
+			toastStore.show({
+				message: String(result.data.error),
+				variant: 'error'
+			});
+		}
+
+		loading = false;
+	}
+
 	async function handleReportSuccess() {
 		toastStore.show({
 			message: 'Reporte enviado correctamente. El equipo de administración lo revisará.',
@@ -261,25 +296,17 @@
 							<div class="space-y-4">
 								<form
 									method="POST"
-									action="?/aprobar"
-									use:enhance={() => {
-										loading = true;
-										return async ({ result, update }) => {
-											if (result.type === 'success' && result.data?.message) {
-												toastStore.show({
-													message: String(result.data.message),
-													variant: 'success'
-												});
-											} else if (result.type === 'failure' && result.data?.error) {
-												toastStore.show({
-													message: String(result.data.error),
-													variant: 'error'
-												});
-											}
-											await update();
-											loading = false;
-										};
-									}}
+								action="?/aprobar"
+								use:enhance={() => {
+									loading = true;
+									return async ({ result, update }) => {
+										await manejarResultadoVotacion(
+											result,
+											update,
+											'Tu voto fue registrado correctamente.'
+										);
+									};
+								}}
 								>
 									<input type="hidden" name="solicitud_id" value={solicitud.id_solicitud} />
 									<button
@@ -346,21 +373,12 @@
 							use:enhance={() => {
 								loading = true;
 								return async ({ result, update }) => {
-									if (result.type === 'success' && result.data?.message) {
-										toastStore.show({
-											message: String(result.data.message),
-											variant: 'success'
-										});
-									} else if (result.type === 'failure' && result.data?.error) {
-										toastStore.show({
-											message: String(result.data.error),
-											variant: 'error'
-										});
-									}
-									await update();
-									loading = false;
-									showRejectModal = false;
-									justificacionRechazo = '';
+									await manejarResultadoVotacion(
+										result,
+										update,
+										'Tu rechazo fue registrado correctamente.',
+										{ cerrarModalRechazo: true }
+									);
 								};
 							}}
 						>

--- a/app/src/routes/(protected)/institucion/solicitar-cierre/+page.server.ts
+++ b/app/src/routes/(protected)/institucion/solicitar-cierre/+page.server.ts
@@ -7,6 +7,7 @@ import { CrearSolicitudFinalizacion } from '$lib/domain/use-cases/proyectos/Crea
 import { redirect, fail } from '@sveltejs/kit';
 import { GestionarEstadoProyecto } from '$lib/domain/use-cases/proyectos/GestionarEstadoProyecto';
 import { prisma } from '$lib/infrastructure/prisma/client';
+import { Prisma } from '@prisma/client';
 
 const ESTADOS_SOLICITUD_ACTIVA = new Set(['', 'pendiente', 'en_revision']);
 
@@ -221,22 +222,39 @@ export const actions: Actions = {
 
 		if (!proyectoId) return fail(400, { message: 'Debe seleccionar un proyecto' });
 
-		const useCase = new CrearSolicitudFinalizacion(
-			new PostgresSolicitudFinalizacionRepository(),
-			new PostgresProyectoRepository(),
-			new PostgresEvidenciaRepository(),
-			new PostgresHistorialDeCambiosRepository()
-		);
-
 		try {
-			const solicitud = await useCase.execute(user.id_usuario!, proyectoId, evidenciaIds);
+			const solicitud = await prisma.$transaction(
+				async (tx) => {
+					const solicitudRepo = new PostgresSolicitudFinalizacionRepository(tx);
+					const proyectoRepo = new PostgresProyectoRepository(tx);
+					const evidenciaRepo = new PostgresEvidenciaRepository(tx);
+					const historialRepo = new PostgresHistorialDeCambiosRepository(tx);
 
-			// Transicionar el proyecto a en_revision
-			const gestionEstado = new GestionarEstadoProyecto(
-				new PostgresProyectoRepository(),
-				new PostgresHistorialDeCambiosRepository()
+					const useCase = new CrearSolicitudFinalizacion(
+						solicitudRepo,
+						proyectoRepo,
+						evidenciaRepo,
+						historialRepo
+					);
+
+					const solicitudCreada = await useCase.execute(
+						user.id_usuario!,
+						proyectoId,
+						evidenciaIds
+					);
+
+					const gestionEstado = new GestionarEstadoProyecto(proyectoRepo, historialRepo);
+					await gestionEstado.enviarASolicitudCierreConEvidencias(
+						proyectoId,
+						user.id_usuario!
+					);
+
+					return solicitudCreada;
+				},
+				{
+					isolationLevel: Prisma.TransactionIsolationLevel.Serializable
+				}
 			);
-			await gestionEstado.enviarASolicitudCierreConEvidencias(proyectoId, user.id_usuario!);
 
 			return { success: true, solicitud };
 		} catch (error: any) {

--- a/app/src/routes/(protected)/institucion/solicitar-cierre/+page.server.ts
+++ b/app/src/routes/(protected)/institucion/solicitar-cierre/+page.server.ts
@@ -52,7 +52,11 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const proyectosDisponibles = allProyectos.filter(
 		(p) =>
 			p.institucion_id === user.id_usuario &&
-			(p.estado === 'pendiente_solicitud_cierre' || p.estado === 'en_curso')
+			p.estado === 'pendiente_solicitud_cierre'
+	);
+
+	const proyectosDisponiblesIds = new Set(
+		proyectosDisponibles.map((proyecto) => Number(proyecto.id_proyecto))
 	);
 
 	let proyectoActual = null;
@@ -65,6 +69,10 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 		const idProyecto = Number(proyectoId);
 
 		if (idProyecto && !isNaN(idProyecto)) {
+			if (!proyectosDisponiblesIds.has(idProyecto)) {
+				throw redirect(303, url.pathname);
+			}
+
 			// CARGA MASIVA Y PROFUNDA (Relaciones completas de Proyecto y Evidencias)
 			const [p, solicitud, rechazadas, evs] = await Promise.all([
 				prisma.proyecto.findUnique({

--- a/app/src/routes/(protected)/institucion/solicitar-cierre/+page.svelte
+++ b/app/src/routes/(protected)/institucion/solicitar-cierre/+page.svelte
@@ -1,5 +1,3 @@
-<!-- TODO: corregir esta ruta -->
-
 <script lang="ts">
 	import Select from '$lib/components/ui/elementos/Select.svelte';
 	import ObjetivoEvidencias from '$lib/components/feature/institucion/ObjetivoEvidencias.svelte';
@@ -386,7 +384,7 @@
 										</p>
 										{#if proyectoSeleccionado}
 											<a
-												href="/institucion/proyectos/{proyectoSeleccionado}/solicitudes-cierre"
+												href={`/institucion/proyectos/${proyectoSeleccionado}/solicitudes-cierre`}
 												class="mt-3 inline-flex text-sm font-semibold text-amber-900 underline hover:text-amber-950"
 											>
 												Ver historial de solicitudes de cierre

--- a/app/src/routes/(protected)/proyectos/[id]/editar/+page.svelte
+++ b/app/src/routes/(protected)/proyectos/[id]/editar/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
 	import CrearProyecto from '$lib/components/feature/institucion/CrearProyecto.svelte';
 	import { isLoading, usuario } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
@@ -9,7 +7,7 @@
 
 	let { data } = $props();
 
-	run(() => {
+	$effect(() => {
 		if (data.form?.titulo) {
 			setBreadcrumbs([
 				BREADCRUMB_ROUTES.proyectos,
@@ -19,7 +17,7 @@
 		}
 	});
 
-	run(() => {
+	$effect(() => {
 		if (!$isLoading) {
 			if ($usuario?.rol !== 'institucion' && $usuario?.rol !== 'administrador') {
 				toastStore.show({

--- a/app/src/routes/(protected)/proyectos/crear/+page.svelte
+++ b/app/src/routes/(protected)/proyectos/crear/+page.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { run } from 'svelte/legacy';
-
 	import CrearProyecto from '$lib/components/feature/institucion/CrearProyecto.svelte';
 	import { goto } from '$app/navigation';
 	import { usuario, isLoading } from '$lib/stores/auth';
@@ -14,7 +12,7 @@
 
 	let { data } = $props();
 
-	run(() => {
+	$effect(() => {
 		if (!$isLoading) {
 			if ($usuario?.rol !== 'institucion') {
 				toastStore.show({

--- a/app/src/routes/(public)/(auth)/registrarse/+page.svelte
+++ b/app/src/routes/(public)/(auth)/registrarse/+page.svelte
@@ -113,6 +113,18 @@
 	});
 
 	const infoPasoActual = $derived(pasosFiltrados[pasoActualSecuencial - 1] || pasosFiltrados[0]);
+	const encabezadoPasoPreferencias = $derived(
+		rol === 'institucion'
+			? {
+					titulo: 'Tu configuración institucional',
+					descripcion:
+						'Definí las causas, tipos de proyectos y formas de participación que mejor representan cómo suele actuar tu institución.'
+				}
+			: {
+					titulo: infoPasoActual.titulo,
+					descripcion: infoPasoActual.descripcion
+				}
+	);
 	let registrando = $state(false);
 	let errorRegistro: string | null = $state(null);
 
@@ -742,10 +754,10 @@
 							<h2
 								class="text-3xl leading-tight font-black tracking-tight text-slate-900 md:text-4xl"
 							>
-								{@render TextHighlight(infoPasoActual.titulo)}
+								{@render TextHighlight(encabezadoPasoPreferencias.titulo)}
 							</h2>
 							<p class="font-medium text-slate-500">
-								{infoPasoActual.descripcion}
+								{encabezadoPasoPreferencias.descripcion}
 							</p>
 						</div>
 
@@ -960,6 +972,7 @@
 
 						<div in:fly={{ y: 30, duration: 800, delay: 400, easing: cubicOut }} class="w-full">
 							<PreferenciasForm
+								{rol}
 								categorias={data.categorias}
 								tiposParticipacion={data.tiposParticipacion}
 								procesando={procesandoFormulario}

--- a/app/src/routes/(public)/faq/+page.svelte
+++ b/app/src/routes/(public)/faq/+page.svelte
@@ -116,7 +116,7 @@
 					variant="secondary"
 					size="sm"
 					customClass="mx-auto block mt-6"
-					on:click={() => {
+					onclick={() => {
 						searchQuery.set('');
 						if (searchInput) searchInput.focus();
 					}}

--- a/app/src/routes/(public)/perfil/[username]/+page.svelte
+++ b/app/src/routes/(public)/perfil/[username]/+page.svelte
@@ -4,7 +4,8 @@
 	import { isAuthenticated, isLoading } from '$lib/stores/auth';
 	import VistaPerfil from '$lib/components/feature/perfil/VistaPerfil.svelte';
 	import type { PageData } from './$types';
-	import { setBreadcrumbs, BREADCRUMB_ROUTES } from '$lib/stores/breadcrumbs';
+	import { clearBreadcrumbs, setBreadcrumbs, BREADCRUMB_ROUTES } from '$lib/stores/breadcrumbs';
+	import { hasProfileBreadcrumbContext } from '$lib/infrastructure/config/breadcrumbs.config';
 
 	let { data } = $props<{ data: PageData }>();
 
@@ -18,20 +19,25 @@
 		proyectoContexto
 	} = $derived.by(() => data);
 
-	// Redirección si es mi perfil y no está autenticado
 	$effect(() => {
 		if (esMiPerfil && !$isLoading && !$isAuthenticated) {
 			goto('/iniciar-sesion');
 		}
 	});
 
-	// Breadcrumbs contextuales
 	$effect(() => {
+		if (!hasProfileBreadcrumbContext(page.url)) {
+			clearBreadcrumbs();
+			return;
+		}
+
 		const from = page.url.searchParams.get('from');
 		const nombrePerfil = perfilUsuario
 			? perfilUsuario.rol === 'institucion'
-				? (perfilUsuario as { nombre_legal?: string; nombre: string }).nombre_legal || perfilUsuario.nombre
-				: (perfilUsuario as { razon_social?: string; nombre: string; apellido: string }).razon_social || `${perfilUsuario.nombre} ${perfilUsuario.apellido}`
+				? (perfilUsuario as { nombre_legal?: string; nombre: string }).nombre_legal ||
+					perfilUsuario.nombre
+				: (perfilUsuario as { razon_social?: string; nombre: string; apellido: string })
+						.razon_social || `${perfilUsuario.nombre} ${perfilUsuario.apellido}`
 			: 'Perfil';
 
 		if (from === 'solicitudes') {
@@ -65,7 +71,7 @@
 				{ label: nombrePerfil }
 			]);
 		} else {
-			setBreadcrumbs([BREADCRUMB_ROUTES.personas, { label: nombrePerfil }]);
+			clearBreadcrumbs();
 		}
 	});
 </script>
@@ -74,7 +80,8 @@
 	<title>
 		{perfilUsuario
 			? perfilUsuario.rol === 'institucion'
-				? (perfilUsuario as { nombre_legal?: string; nombre: string }).nombre_legal || perfilUsuario.nombre
+				? (perfilUsuario as { nombre_legal?: string; nombre: string }).nombre_legal ||
+					perfilUsuario.nombre
 				: `${perfilUsuario.nombre} ${perfilUsuario.apellido}`
 			: 'Perfil'} - Conectando Corazones
 	</title>

--- a/app/src/routes/(public)/proyectos/[id]/+page.svelte
+++ b/app/src/routes/(public)/proyectos/[id]/+page.svelte
@@ -13,7 +13,7 @@
 		construirDireccionCompleta,
 		generarUrlGoogleMaps
 	} from '$lib/utils/util-proyectos';
-	import { goto, pushState, invalidateAll } from '$app/navigation';
+	import { goto, pushState, invalidateAll, preloadData } from '$app/navigation';
 	import GestionarProyectoDropdown from '$lib/components/feature/proyectos/GestionarProyectoDropdown.svelte';
 
 	let { data }: { data: PageData } = $props();
@@ -508,7 +508,7 @@
 					acc.push({
 						label: 'Evaluar finalización',
 						icon: ClipboardDocumentCheck,
-						onclick: () => goto(`/colaborador/proyectos/${proyecto.id_proyecto}/evaluar-cierre`)
+						onclick: irAEvaluarFinalizacion
 					});
 				}
 			}
@@ -570,6 +570,22 @@
 
 		return acc;
 	});
+
+	$effect(() => {
+		if (
+			mostrarMenuGestion &&
+			esColaboradorAprobado &&
+			estadoCodigo === 'en_revision' &&
+			proyecto?.id_proyecto
+		) {
+			void preloadData(`/colaborador/proyectos/${proyecto.id_proyecto}/evaluar-cierre`);
+		}
+	});
+
+	function irAEvaluarFinalizacion() {
+		if (!proyecto?.id_proyecto) return;
+		goto(`/colaborador/proyectos/${proyecto.id_proyecto}/evaluar-cierre`);
+	}
 
 	async function handleReportSuccess() {
 		if ($usuario?.id_usuario && proyecto?.id_proyecto) {

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -1,34 +1,9 @@
 import type { LayoutServerLoad } from './$types';
-import { PostgresProyectoRepository } from '$lib/infrastructure/supabase/postgres/proyecto.repo';
 
-const OMITIR_RESUMEN_PROYECTOS_EN = /^\/colaborador\/proyectos\/[^/]+\/evaluar-cierre\/?$/;
-
-export const load: LayoutServerLoad = async ({ locals, url }) => {
-	try {
-		if (OMITIR_RESUMEN_PROYECTOS_EN.test(url.pathname)) {
-			return {
-				proyectos: [],
-				session: locals.session,
-				usuario: locals.usuario ? locals.usuario.toPOJO() : null
-			};
-		}
-
-		const repo = new PostgresProyectoRepository();
-		// Usar findAllSummary() en lugar de findAll() para reducir datos cargados
-		const proyectos = await repo.findAllSummary();
-
-		return {
-			proyectos: JSON.parse(JSON.stringify(proyectos)),
-			session: locals.session,
-			usuario: locals.usuario ? locals.usuario.toPOJO() : null
-		};
-	} catch (error) {
-		console.error('Error en LayoutServerLoad:', error);
-		return {
-			proyectos: [],
-			session: locals.session,
-			usuario: locals.usuario ? locals.usuario.toPOJO() : null,
-			error: 'No se pudieron cargar algunos datos globales.'
-		};
-	}
+export const load: LayoutServerLoad = async ({ locals, depends }) => {
+	depends('supabase:auth');
+	return {
+		session: locals.session,
+		usuario: locals.usuario ? locals.usuario.toPOJO() : null
+	};
 };

--- a/app/src/routes/+layout.server.ts
+++ b/app/src/routes/+layout.server.ts
@@ -1,8 +1,18 @@
 import type { LayoutServerLoad } from './$types';
 import { PostgresProyectoRepository } from '$lib/infrastructure/supabase/postgres/proyecto.repo';
 
-export const load: LayoutServerLoad = async ({ locals }) => {
+const OMITIR_RESUMEN_PROYECTOS_EN = /^\/colaborador\/proyectos\/[^/]+\/evaluar-cierre\/?$/;
+
+export const load: LayoutServerLoad = async ({ locals, url }) => {
 	try {
+		if (OMITIR_RESUMEN_PROYECTOS_EN.test(url.pathname)) {
+			return {
+				proyectos: [],
+				session: locals.session,
+				usuario: locals.usuario ? locals.usuario.toPOJO() : null
+			};
+		}
+
 		const repo = new PostgresProyectoRepository();
 		// Usar findAllSummary() en lugar de findAll() para reducir datos cargados
 		const proyectos = await repo.findAllSummary();

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -40,9 +40,7 @@
 		: null;
 	let session = $derived(data.session);
 
-	let showBreadcrumbs = $derived(
-		shouldShowBreadcrumbs(page.url.pathname) && $breadcrumbs.length >= 2
-	);
+	let showBreadcrumbs = $derived(shouldShowBreadcrumbs(page.url) && $breadcrumbs.length >= 2);
 
 	$effect(() => {
 		beforeNavigate(untrack(() => clearBreadcrumbs));

--- a/app/src/routes/+layout.svelte
+++ b/app/src/routes/+layout.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import '../app.css';
 	import type { LayoutData } from './$types';
+	import { createBrowserClient, parse, serialize } from '@supabase/ssr';
+	import { env } from '$lib/infrastructure/config/env';
 	import Header from '$lib/components/layout/Header.svelte';
 	import Footer from '$lib/components/layout/Footer.svelte';
 	import Breadcrumbs from '$lib/components/ui/navegacion/Breadcrumbs.svelte';
@@ -10,10 +12,9 @@
 	import ScrollToTop from '$lib/components/ui/navegacion/ScrollToTop.svelte';
 	import { beforeNavigate, invalidate } from '$app/navigation';
 	import { browser } from '$app/environment';
-	import { canAccessRoute, isLoading, authStore, unauthenticatedState, type AuthState } from '$lib/stores/auth';
+	import { syncAuthState } from '$lib/stores/auth';
 	import { toastStore } from '$lib/stores/toast';
 	import ToastHost from '$lib/components/ui/feedback/ToastHost.svelte';
-	import { goto } from '$app/navigation';
 	import { untrack } from 'svelte';
 
 	import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
@@ -22,17 +23,35 @@
 	import type { Snippet } from 'svelte';
 	let { children, data }: { data: LayoutData; children: Snippet } = $props();
 
-	let supabase = $derived(data.supabase);
+	const supabase = browser
+		? createBrowserClient(env.SUPABASE_URL || '', env.SUPABASE_ANON_KEY || '', {
+				cookies: {
+					get(key) {
+						return parse(document.cookie)[key];
+					},
+					set(key, value, options) {
+						document.cookie = serialize(key, value, options);
+					},
+					remove(key, options) {
+						document.cookie = serialize(key, '', { ...options, maxAge: 0 });
+					}
+				}
+			})
+		: null;
 	let session = $derived(data.session);
 
 	let showBreadcrumbs = $derived(
 		shouldShowBreadcrumbs(page.url.pathname) && $breadcrumbs.length >= 2
 	);
 
-	let mounted = $state(false);
-
 	$effect(() => {
 		beforeNavigate(untrack(() => clearBreadcrumbs));
+	});
+
+	$effect(() => {
+		if (!supabase) {
+			return;
+		}
 
 		const { data: subscription } = supabase.auth.onAuthStateChange(
 			(event: AuthChangeEvent, _session: Session | null) => {
@@ -43,52 +62,11 @@
 			}
 		);
 
-		// Inicializar estado global de auth con datos del servidor
-		let authValue: AuthState;
-		const unsubscribe = authStore.subscribe(v => { authValue = v; });
-		unsubscribe(); 
-
-		const userFromData = data.usuario;
-
-		if (userFromData) {
-			const usuarioInstance = new Usuario(userFromData);
-			// Solo actualizar si el usuario cambió o no estaba autenticado
-			// id_usuario es el identificador en nuestra entidad Usuario
-			if (!authValue!.isAuthenticated || authValue!.usuario?.id_usuario !== userFromData.id_usuario) {
-				authStore.update((s) => ({
-					...s,
-					usuario: usuarioInstance,
-					isAuthenticated: true,
-					isLoading: false
-				}));
-			}
-		} else {
-			if (session) {
-				if (authValue!.isLoading) {
-					authStore.update((s) => ({ ...s, isLoading: false }));
-				}
-			} else {
-				// Sin sesión, solo resetear si no estábamos ya en unauthenticatedState
-				if (authValue!.isAuthenticated || authValue!.isLoading) {
-					authStore.set(unauthenticatedState);
-				}
-			}
-		}
-
-		mounted = true;
-
 		return () => subscription.subscription.unsubscribe();
 	});
 
 	$effect(() => {
-		// Acceso reactivo a mounted e isLoading
-		// No bloqueamos el renderizado con isLoading, permitimos que children() se rinda siempre.
-		// El guard de ruta solo actúa después de que el sistema está montado.
-		if (mounted && !$isLoading) {
-			if (!canAccessRoute(page.url.pathname)) {
-				goto('/iniciar-sesion');
-			}
-		}
+		syncAuthState(data.usuario ? new Usuario(data.usuario) : null);
 	});
 
 	$effect(() => {
@@ -138,7 +116,7 @@
 	});
 </script>
 
-<Header proyectos={data.proyectos} />
+<Header />
 <ToastHost />
 
 {#if showBreadcrumbs}

--- a/app/src/routes/+layout.ts
+++ b/app/src/routes/+layout.ts
@@ -1,36 +1,6 @@
-import { createBrowserClient, isBrowser, parse, serialize } from '@supabase/ssr';
-import { env } from '$lib/infrastructure/config/env';
 import type { LayoutLoad } from './$types';
 
-export const load: LayoutLoad = async ({ fetch, data, depends }) => {
+export const load: LayoutLoad = async ({ data, depends }) => {
 	depends('supabase:auth');
-
-	const supabase = createBrowserClient(env.SUPABASE_URL || '', env.SUPABASE_ANON_KEY || '', {
-		global: {
-			fetch
-		},
-		cookies: {
-			get(key) {
-				if (!isBrowser()) {
-					return JSON.stringify(data.session);
-				}
-				const cookie = parse(document.cookie);
-				return cookie[key];
-			},
-			set(key, value, options) {
-				if (!isBrowser()) return;
-				document.cookie = serialize(key, value, options);
-			},
-			remove(key, options) {
-				if (!isBrowser()) return;
-				document.cookie = serialize(key, '', { ...options, maxAge: 0 });
-			}
-		}
-	});
-
-	const {
-		data: { session }
-	} = await supabase.auth.getSession();
-
-	return { ...data, supabase, session };
+	return { ...data, session: data.session };
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -8,19 +8,22 @@
 	import SoporteSection from '$lib/components/feature/home/SoporteSection.svelte';
 	import ProyectosDestacadosSection from '$lib/components/feature/home/ProyectosDestacadosSection.svelte';
 	import { clearBreadcrumbs } from '$lib/stores/breadcrumbs';
+	import { obtenerRutaPanelPorRol } from '$lib/utils/util-usuarios';
 	import type { PageData } from './$types';
 
 	let { data }: { data: PageData } = $props();
+	let ctaLabel = $derived(data.usuario ? 'Mi panel' : 'Registrarse');
+	let ctaHref = $derived(data.usuario ? obtenerRutaPanelPorRol(data.usuario.rol) : '/registrarse');
 
 	$effect(() => {
 		clearBreadcrumbs();
 	});
 </script>
 
-<HeroSection />
+<HeroSection {ctaLabel} {ctaHref} />
 <ComoFuncionaSection />
 <HistoriaSection />
-<CTASection />
+<CTASection {ctaLabel} {ctaHref} />
 <TestimoniosSection />
 <FaqSection />
 <ProyectosDestacadosSection proyectos={data.proyectosDestacados} />


### PR DESCRIPTION
Cierra: #107 

- [X] Completar migración a Svelte 5 y errores heredados
- [X] Corregir ruta /evaluar-cierre (no renderizaba correctamente por problema en el SSR y mantenía DOM anterior)
- [X] Implementar atomicidad en "evaluar-cierre" y "solicitar-cierre" (misma transacción) para evitar estados inconsistentes
- [X] Corregir /evaluar-cierre para que traiga la última solicitudFinalizacion del proyecto (filtrando por estado "pendiente", antes la traía incluso si el estado era "aprobada")
- [X] Corregir el estado visual de las pestañas en "Mis proyectos" para que el activo/inactivo se renderice correctamente
- [X] Mejorar CTA del hero para que, si hay un usuario autenticado, muestre "Mi panel" en lugar de "Registrarse"
- [X] Mejorar los textos del form para registrarse en la sección de "Preferencias" si el usuario es una Institución para que hablen de causas, tipos de proyectos habituales... para diferenciarse de colaboradores
- [X] Mejorar la sección de "Sobre este perfil" para Instituciones para diferenciar del perfil de Colaboradores de modo que muestre sus causas y proyectos frecuentes (categorías) y sus participaciones más alineadas (tipos de participación)
- [X] Corregir Breadcrumb para que no se muestre en el perfil del usuario si no hay rutas previas o nav profunda
- [X] Agregar fallback visual al avatar/logo si el usuario no cargó una imagen

(Entre otras cosas)