### PR TITLE
Implementar reseñas y heatmap de actividad en paneles de colaborador e institución

### DIFF
--- a/app/src/lib/components/dashboard/DashboardColaborador.svelte
+++ b/app/src/lib/components/dashboard/DashboardColaborador.svelte
@@ -6,7 +6,6 @@
 	import MetricasPanel from './colaborador/MetricasPanel.svelte';
 	import SeguimientoObjetivos from './colaborador/SeguimientoObjetivos.svelte';
 	import EstadisticasAyuda from './colaborador/EstadisticasAyuda.svelte';
-	import ActividadReciente from './colaborador/ActividadReciente.svelte';
 	import UltimasResenas from './colaborador/UltimasResenas.svelte';
 	import Novedades from './Novedades.svelte';
 	import EstadisticasProyectoModal from './colaborador/EstadisticasProyectoModal.svelte';
@@ -461,7 +460,6 @@
 
 				<!-- Últimas Reseñas -->
 				<div class="min-h-[300px]">
-					<!-- TODO: implementar módulo de reseñas -->
 					<UltimasResenas resenas={data.ultimasResenas} />
 				</div>
 			</div>

--- a/app/src/lib/components/dashboard/colaborador/HeatmapActividad.svelte
+++ b/app/src/lib/components/dashboard/colaborador/HeatmapActividad.svelte
@@ -27,7 +27,7 @@
 				date.setDate(today.getDate() - ((weeksToShow - 1 - w) * 7 + (6 - d)));
 				const dateStr = date.toISOString().split('T')[0];
 
-				const found = data.find((d: { fecha: string; nivel: number }) => d.fecha === dateStr);
+				const found = data.find((d: { fecha: string; intensidad: number }) => d.fecha === dateStr);
 				week.push({
 					date: dateStr,
 					intensity: found ? found.intensidad : 0
@@ -66,7 +66,7 @@
 				<div class="flex flex-col gap-1">
 					{#each week as day}
 						<div
-							title={`${day.date}: ${day.intensity} actividades`}
+							title={`${day.date.split('-').reverse().join('/')}: ${day.intensity} actividades`}
 							class="h-3 w-3 rounded-sm transition-colors hover:border hover:border-white/20 {getColor(
 								day.intensity
 							)}"
@@ -79,7 +79,6 @@
 
 	<div class="mt-4 flex items-center gap-2 rounded-lg bg-white/5 p-3 text-xs text-slate-400">
 		<Info size={14} class="text-blue-400" />
-		<!-- TODO: implementar historial de cambios -->
 		<p>Tu actividad impulsa proyectos. ¡Seguí así!</p>
 	</div>
 </div>

--- a/app/src/lib/components/dashboard/colaborador/UltimasResenas.svelte
+++ b/app/src/lib/components/dashboard/colaborador/UltimasResenas.svelte
@@ -1,4 +1,3 @@
-<!-- TODO: implementar módulo de reseñas -->
 <script lang="ts">
 	import { Star } from 'lucide-svelte';
 

--- a/app/src/lib/domain/use-cases/colaboraciones/ObtenerDashboardColaborador.ts
+++ b/app/src/lib/domain/use-cases/colaboraciones/ObtenerDashboardColaborador.ts
@@ -1,13 +1,17 @@
 import type { ColaboracionRepository } from '$lib/domain/repositories/ColaboracionRepository';
 import type { ProyectoRepository } from '$lib/domain/repositories/ProyectoRepository';
 import type { UsuarioRepository } from '$lib/domain/repositories/UsuarioRepository';
+import type { ResenaRepository } from '$lib/domain/repositories/ResenaRepository';
+import type { HistorialDeCambiosRepository } from '$lib/domain/repositories/HistorialDeCambiosRepository';
 import type { ColaboradorDashboardData } from '$lib/components/dashboard/colaborador/types';
 
 export class ObtenerDashboardColaborador {
 	constructor(
 		private colaboracionRepo: ColaboracionRepository,
 		private proyectoRepo: ProyectoRepository,
-		private usuarioRepo: UsuarioRepository
+		private usuarioRepo: UsuarioRepository,
+		private resenaRepo: ResenaRepository,
+		private historialRepo: HistorialDeCambiosRepository
 	) {}
 
 	async execute(colaboradorId: number): Promise<ColaboradorDashboardData> {
@@ -104,10 +108,11 @@ export class ObtenerDashboardColaborador {
 		);
 		const estadisticasAyuda = this.calcularEstadisticasAyuda(colaboraciones);
 
-		const proyectosComunidad = await this.calcularProyectosRecomendados(
-			colaborador,
-			proyectosColaborador
-		);
+		const [proyectosComunidad, ultimasResenas, heatmapActividad] = await Promise.all([
+			this.calcularProyectosRecomendados(colaborador, proyectosColaborador),
+			this.obtenerUltimasResenas(colaboradorId),
+			this.calcularHeatmapActividad(colaboradorId)
+		]);
 
 		return {
 			info: {
@@ -138,10 +143,51 @@ export class ObtenerDashboardColaborador {
 			seguimientoObjetivos,
 			estadisticasAyuda,
 			topColaboradores: [],
-			ultimasResenas: [],
-			heatmapActividad: [],
+			ultimasResenas,
+			heatmapActividad,
 			proyectosComunidad
 		};
+	}
+
+	private async obtenerUltimasResenas(colaboradorId: number) {
+		const resenas = await this.resenaRepo.findByObjetoAprobadas('usuario', colaboradorId, 5);
+
+		return resenas.map((r) => ({
+			id: r.id_resena?.toString() || '',
+			usuario: r.username || 'Usuario anónimo',
+			avatarUrl: r.autor?.url_foto ?? undefined,
+			calificacion: r.puntaje || 0,
+			comentario: r.contenido || '',
+			fecha: r.created_at?.toISOString() ?? new Date().toISOString()
+		}));
+	}
+
+	private async calcularHeatmapActividad(colaboradorId: number) {
+		const desde = new Date();
+		desde.setDate(desde.getDate() - 182);
+
+		const cambios = await this.historialRepo.findAll({ usuario_id: colaboradorId, desde });
+
+		const conteoPorDia = new Map<string, number>();
+		for (const cambio of cambios) {
+			if (!cambio.created_at) continue;
+			const fecha = new Date(cambio.created_at);
+			const clave = fecha.toISOString().split('T')[0];
+			conteoPorDia.set(clave, (conteoPorDia.get(clave) || 0) + 1);
+		}
+
+		return Array.from(conteoPorDia.entries()).map(([fecha, conteo]) => ({
+			fecha,
+			intensidad: this.mapearIntensidad(conteo)
+		}));
+	}
+
+	private mapearIntensidad(conteo: number): number {
+		if (conteo <= 0) return 0;
+		if (conteo === 1) return 1;
+		if (conteo <= 3) return 2;
+		if (conteo <= 5) return 3;
+		return 4;
 	}
 
 	private calcularEstadisticasProyectos(proyectos: any[], colaboraciones: any[]) {

--- a/app/src/lib/domain/use-cases/institucion/ObtenerDashboardInstitucion.ts
+++ b/app/src/lib/domain/use-cases/institucion/ObtenerDashboardInstitucion.ts
@@ -660,15 +660,15 @@ export class ObtenerDashboardInstitucion {
 	}
 
 	private async obtenerUltimasResenas(institucionId: number) {
-		const resenas = await this.resenaRepo.findByObjetoAprobadas('institucion', institucionId, 5);
+		const resenas = await this.resenaRepo.findByObjetoAprobadas('usuario', institucionId, 5);
 
 		return resenas.map((r) => ({
 			id: r.id_resena?.toString() || '',
 			usuario: r.username || 'Usuario anónimo',
-			avatarUrl: undefined,
+			avatarUrl: r.autor?.url_foto ?? undefined,
 			calificacion: r.puntaje || 0,
 			comentario: r.contenido || '',
-			fecha: new Date().toISOString()
+			fecha: r.created_at?.toISOString() ?? new Date().toISOString()
 		}));
 	}
 

--- a/app/src/routes/(protected)/colaborador/mi-panel/+page.server.ts
+++ b/app/src/routes/(protected)/colaborador/mi-panel/+page.server.ts
@@ -3,6 +3,8 @@ import { ObtenerDashboardColaborador } from '$lib/domain/use-cases/colaboracione
 import { PostgresColaboracionRepository } from '$lib/infrastructure/supabase/postgres/colaboracion.repo';
 import { PostgresProyectoRepository } from '$lib/infrastructure/supabase/postgres/proyecto.repo';
 import { PostgresUsuarioRepository } from '$lib/infrastructure/supabase/postgres/usuario.repo';
+import { PostgresResenaRepository } from '$lib/infrastructure/supabase/postgres/resena.repo';
+import { PostgresHistorialDeCambiosRepository } from '$lib/infrastructure/supabase/postgres/historial-cambios.repo';
 
 /**
  * Carga de datos para el dashboard del colaborador.
@@ -15,11 +17,15 @@ export const load: PageServerLoad = async ({ locals }) => {
 		const colaboracionRepo = new PostgresColaboracionRepository();
 		const proyectoRepo = new PostgresProyectoRepository();
 		const usuarioRepo = new PostgresUsuarioRepository();
+		const resenaRepo = new PostgresResenaRepository();
+		const historialRepo = new PostgresHistorialDeCambiosRepository();
 
 		const obtenerDashboard = new ObtenerDashboardColaborador(
 			colaboracionRepo,
 			proyectoRepo,
-			usuarioRepo
+			usuarioRepo,
+			resenaRepo,
+			historialRepo
 		);
 
 		const dashboardData = await obtenerDashboard.execute(usuario.id_usuario!);


### PR DESCRIPTION
# 🚀 Pull Request – Conectando Corazones

**Resumen del cambio**
Se conectaron dos secciones del dashboard del colaborador que existían en la UI pero nunca mostraban datos reales: las últimas reseñas recibidas y el heatmap de actividad. Para las reseñas se reutilizó ResenaRepository.findByObjetoAprobadas, y para el heatmap se usa HistorialDeCambiosRepository.findAll con filtro de fecha, agrupando eventos por día y mapeando a niveles de intensidad 0–4. 
Adicionalmente se corrigió un bug en el dashboard de institución donde las reseñas nunca aparecían porque se buscaban con tipo_objeto='institucion' (valor inválido en el dominio) en lugar de 'usuario', y se aprovechó para traer el avatar y la fecha reales en lugar de los valores hardcodeados.

## 📝 Checklist
 
- [x]  Fix bug dashboard institución: findByObjetoAprobadas('institucion', ...) → 'usuario'
- [x]  Fix avatarUrl hardcodeado (undefined) → r.autor?.url_foto en institución
- [x] Fix fecha hardcodeada (new Date()) → r.created_at?.toISOString() en institución
- [x] Inyectar ResenaRepository en ObtenerDashboardColaborador
- [x] Inyectar HistorialDeCambiosRepository en ObtenerDashboardColaborador
- [x] Implementar obtenerUltimasResenas en use case del colaborador
- [x] Implementar calcularHeatmapActividad con agrupación por día e intensidad
- [x] Cablear PostgresResenaRepository y PostgresHistorialDeCambiosRepository en +page.server.ts
- [x] Eliminar import ActividadReciente no utilizado en DashboardColaborador.svelte
- [x] Eliminar comentarios TODO obsoletos

## 📸 Capturas

**Reseñas en Institución**
<img width="479" height="629" alt="image" src="https://github.com/user-attachments/assets/9fe26b9b-a913-4113-be91-ef3b84e3c8c5" />

**Heatmap y reseñas en Colaborador**

<img width="1015" height="627" alt="image" src="https://github.com/user-attachments/assets/1fd23d51-9931-49f4-8035-5b2b246bb9eb" />
