### PR TITLE
feat: notificar por email eventos críticos a adminstradores

### DIFF
--- a/app/NOTIFICACIONES_ADMIN_EMAIL.md
+++ b/app/NOTIFICACIONES_ADMIN_EMAIL.md
@@ -1,0 +1,70 @@
+# Notificaciones Email Admin
+
+Este documento define los mensajes de email para eventos que requieren atención del equipo administrador.
+
+## Configuración
+
+- `RESEND_API_KEY`: API key para envío (obligatoria).
+- `ADMIN_ALERTS_EMAIL_FROM`: remitente visible (opcional).
+- `ADMIN_ALERTS_EMAILS`: lista de correos destino separada por comas (opcional).
+- `APP_BASE_URL`: base URL para construir links al panel admin (opcional).
+
+Si `ADMIN_ALERTS_EMAILS` no está definida, el sistema busca emails de usuarios activos con rol `administrador`.
+
+## Mensajes Activos
+
+### 1) Nueva solicitud de verificación pendiente
+
+- **Trigger:** carga de documentación de verificación o creación de solicitud de verificación.
+- **Asunto:** `Nueva solicitud de verificación pendiente`
+- **Resumen:** `Una institución cargó documentación y requiere revisión administrativa.`
+- **Detalle:**
+  - Usuario ID
+  - Username
+  - Tipo
+  - Archivos adjuntos
+  - Panel de revisión
+
+### 2) Nueva cuenta institucional registrada
+
+- **Trigger:** registro exitoso de una institución.
+- **Asunto:** `Nueva cuenta institucional registrada`
+- **Resumen:** `Se creó una nueva cuenta de institución y puede requerir gestión administrativa.`
+- **Detalle:**
+  - Usuario ID
+  - Username
+  - Email
+  - Panel de gestión
+
+### 3) Nuevo reporte recibido
+
+- **Trigger:** creación de reporte sobre `Usuario` o `Proyecto`.
+- **Asunto:** `Nuevo reporte sobre usuario` / `Nuevo reporte sobre proyecto`
+- **Resumen:** `Se recibió un nuevo reporte que requiere revisión administrativa.`
+- **Detalle:**
+  - Tipo de objeto
+  - ID objeto reportado
+  - Motivo
+  - Reportante ID
+  - Reportante
+  - Panel de reportes
+
+### 4) Proyecto escalado a auditoría
+
+- **Trigger:** rechazo de solicitud de cierre que lleva el proyecto a estado `en_auditoria`.
+- **Asunto:** `Proyecto escalado a auditoría`
+- **Resumen:** `Un proyecto pasó automáticamente a estado de auditoría tras rechazos en la solicitud de cierre.`
+- **Detalle:**
+  - Proyecto ID
+  - Proyecto
+  - Solicitud de cierre ID
+  - Colaborador que rechazó
+  - Username colaborador
+  - Panel de administración
+
+## Criterios de tono
+
+- Mensaje corto y accionable.
+- Incluir IDs para trazabilidad.
+- Incluir link al panel para resolución rápida.
+- No exponer datos sensibles innecesarios.

--- a/app/src/lib/server/servicio-notificaciones-admin.ts
+++ b/app/src/lib/server/servicio-notificaciones-admin.ts
@@ -1,0 +1,185 @@
+import { env } from '$env/dynamic/private';
+import { prisma } from '$lib/infrastructure/prisma/client';
+
+type DatosNotificacionAdmin = {
+	titulo: string;
+	resumen: string;
+	detalles: Array<{ etiqueta: string; valor: string }>;
+};
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+
+function normalizarListaCorreos(value: string | undefined): string[] {
+	if (!value) return [];
+	return value
+		.split(',')
+		.map((item) => item.trim())
+		.filter((item) => item.length > 0);
+}
+
+async function obtenerCorreosAdminsDesdeDB(): Promise<string[]> {
+	const rows = await prisma.contacto.findMany({
+		where: {
+			tipo_contacto: 'email',
+			usuario: {
+				rol: 'administrador',
+				estado: { not: 'inactivo' }
+			}
+		},
+		select: { valor: true }
+	});
+
+	return [...new Set(rows.map((row) => row.valor.trim()).filter((email) => email.length > 0))];
+}
+
+async function obtenerCorreosDestinatarios(): Promise<string[]> {
+	const fromEnv = normalizarListaCorreos(env.ADMIN_ALERTS_EMAILS);
+	if (fromEnv.length > 0) return fromEnv;
+	return obtenerCorreosAdminsDesdeDB();
+}
+
+function renderHtml(payload: DatosNotificacionAdmin): string {
+	const detalleHtml = payload.detalles
+		.map((detalle) => `<li><strong>${detalle.etiqueta}:</strong> ${detalle.valor}</li>`)
+		.join('');
+
+	return `
+		<div style="font-family: Arial, sans-serif; color: #1f2937; line-height: 1.5;">
+			<h2 style="margin-bottom: 8px;">${payload.titulo}</h2>
+			<p style="margin-top: 0;">${payload.resumen}</p>
+			<ul>${detalleHtml}</ul>
+		</div>
+	`;
+}
+
+function renderText(payload: DatosNotificacionAdmin): string {
+	const detalleText = payload.detalles.map((detalle) => `- ${detalle.etiqueta}: ${detalle.valor}`).join('\n');
+	return `${payload.titulo}\n\n${payload.resumen}\n\n${detalleText}`;
+}
+
+async function enviarEmail(destinatarios: string[], payload: DatosNotificacionAdmin): Promise<void> {
+	const apiKey = env.RESEND_API_KEY;
+	const sender = env.ADMIN_ALERTS_EMAIL_FROM || 'Conectando Corazones <onboarding@conectando-corazones.app>';
+
+	if (!apiKey) {
+		console.warn('[ServicioNotificacionesAdmin] RESEND_API_KEY no configurada. Se omite envío de email.');
+		return;
+	}
+
+	if (destinatarios.length === 0) {
+		console.warn('[ServicioNotificacionesAdmin] No hay destinatarios administradores para notificar.');
+		return;
+	}
+
+	const response = await fetch(RESEND_ENDPOINT, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			from: sender,
+			to: destinatarios,
+			subject: payload.titulo,
+			html: renderHtml(payload),
+			text: renderText(payload)
+		})
+	});
+
+	if (!response.ok) {
+		const detail = await response.text().catch(() => '');
+		throw new Error(`Error enviando email admin (${response.status}): ${detail}`);
+	}
+}
+
+async function notificar(payload: DatosNotificacionAdmin): Promise<void> {
+	try {
+		const destinatarios = await obtenerCorreosDestinatarios();
+		await enviarEmail(destinatarios, payload);
+	} catch (error) {
+		console.error('[ServicioNotificacionesAdmin] Falló notificación a admins:', error);
+	}
+}
+
+export async function notificarSolicitudVerificacionAdmin(input: {
+	usuarioId: number;
+	username?: string;
+	tipoSolicitud: string;
+	cantidadArchivos?: number;
+}): Promise<void> {
+	const panelUrl = env.APP_BASE_URL ? `${env.APP_BASE_URL}/admin` : '/admin';
+	await notificar({
+		titulo: 'Nueva solicitud de verificación pendiente',
+		resumen: 'Una institución cargó documentación y requiere revisión administrativa.',
+		detalles: [
+			{ etiqueta: 'Usuario ID', valor: String(input.usuarioId) },
+			{ etiqueta: 'Username', valor: input.username || 'Sin dato' },
+			{ etiqueta: 'Tipo', valor: input.tipoSolicitud },
+			{ etiqueta: 'Archivos adjuntos', valor: String(input.cantidadArchivos ?? 0) },
+			{ etiqueta: 'Panel de revisión', valor: panelUrl }
+		]
+	});
+}
+
+export async function notificarNuevaCuentaInstitucionAdmin(input: {
+	usuarioId: number;
+	username?: string;
+	email?: string;
+}): Promise<void> {
+	const panelUrl = env.APP_BASE_URL ? `${env.APP_BASE_URL}/admin` : '/admin';
+	await notificar({
+		titulo: 'Nueva cuenta institucional registrada',
+		resumen: 'Se creó una nueva cuenta de institución y puede requerir gestión administrativa.',
+		detalles: [
+			{ etiqueta: 'Usuario ID', valor: String(input.usuarioId) },
+			{ etiqueta: 'Username', valor: input.username || 'Sin dato' },
+			{ etiqueta: 'Email', valor: input.email || 'Sin dato' },
+			{ etiqueta: 'Panel de gestión', valor: panelUrl }
+		]
+	});
+}
+
+export async function notificarNuevoReporteAdmin(input: {
+	tipoObjeto: 'Usuario' | 'Proyecto';
+	idObjeto: number;
+	motivo: string;
+	reportanteId: number;
+	reportanteUsername?: string;
+}): Promise<void> {
+	const panelUrl = env.APP_BASE_URL ? `${env.APP_BASE_URL}/admin` : '/admin';
+	await notificar({
+		titulo: `Nuevo reporte sobre ${input.tipoObjeto.toLowerCase()}`,
+		resumen: 'Se recibió un nuevo reporte que requiere revisión administrativa.',
+		detalles: [
+			{ etiqueta: 'Tipo de objeto', valor: input.tipoObjeto },
+			{ etiqueta: 'ID objeto reportado', valor: String(input.idObjeto) },
+			{ etiqueta: 'Motivo', valor: input.motivo },
+			{ etiqueta: 'Reportante ID', valor: String(input.reportanteId) },
+			{ etiqueta: 'Reportante', valor: input.reportanteUsername || 'Sin dato' },
+			{ etiqueta: 'Panel de reportes', valor: panelUrl }
+		]
+	});
+}
+
+export async function notificarProyectoEnAuditoriaAdmin(input: {
+	proyectoId: number;
+	tituloProyecto?: string;
+	solicitudId: number;
+	colaboradorId: number;
+	colaboradorUsername?: string;
+}): Promise<void> {
+	const panelUrl = env.APP_BASE_URL ? `${env.APP_BASE_URL}/admin` : '/admin';
+	await notificar({
+		titulo: 'Proyecto escalado a auditoría',
+		resumen:
+			'Un proyecto pasó automáticamente a estado de auditoría tras rechazos en la solicitud de cierre.',
+		detalles: [
+			{ etiqueta: 'Proyecto ID', valor: String(input.proyectoId) },
+			{ etiqueta: 'Proyecto', valor: input.tituloProyecto || 'Sin dato' },
+			{ etiqueta: 'Solicitud de cierre ID', valor: String(input.solicitudId) },
+			{ etiqueta: 'Colaborador que rechazó', valor: String(input.colaboradorId) },
+			{ etiqueta: 'Username colaborador', valor: input.colaboradorUsername || 'Sin dato' },
+			{ etiqueta: 'Panel de administración', valor: panelUrl }
+		]
+	});
+}

--- a/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.server.ts
+++ b/app/src/routes/(protected)/colaborador/proyectos/[id]/evaluar-cierre/+page.server.ts
@@ -6,6 +6,7 @@ import { PostgresEvaluacionRepository } from '$lib/infrastructure/supabase/postg
 import { PostgresSolicitudFinalizacionRepository } from '$lib/infrastructure/supabase/postgres/solicitud-finalizacion.repo';
 import { PostgresHistorialDeCambiosRepository } from '$lib/infrastructure/supabase/postgres/historial-cambios.repo';
 import { RegistrarEvaluacion } from '$lib/domain/use-cases/evaluacion/RegistrarEvaluacion';
+import { notificarProyectoEnAuditoriaAdmin } from '$lib/server/servicio-notificaciones-admin';
 
 const proyectoRepo = new PostgresProyectoRepository();
 const colaboracionRepo = new PostgresColaboracionRepository();
@@ -132,6 +133,17 @@ export const actions: Actions = {
 				voto: 'rechazado',
 				justificacion
 			});
+
+			const proyectoActualizado = await proyectoRepo.findById(proyectoId);
+			if (proyectoActualizado?.estado === 'en_auditoria') {
+				await notificarProyectoEnAuditoriaAdmin({
+					proyectoId,
+					tituloProyecto: proyectoActualizado.titulo,
+					solicitudId,
+					colaboradorId: user.id_usuario!,
+					colaboradorUsername: user.username
+				});
+			}
 
 			return { success: true };
 		} catch (error) {

--- a/app/src/routes/api/registro/institucion/+server.ts
+++ b/app/src/routes/api/registro/institucion/+server.ts
@@ -4,6 +4,7 @@ import type { RegisterInstitucionInput } from '$lib/stores/auth';
 import { RegistrationService } from '$lib/server/registration.service';
 import { RateLimitService, AUTH_RATE_LIMITS } from '$lib/server/rate-limit.service';
 import { getClientIp } from '$lib/server/request.helper';
+import { notificarNuevaCuentaInstitucionAdmin } from '$lib/server/servicio-notificaciones-admin';
 
 export const POST: RequestHandler = async (event) => {
 	const { request } = event;
@@ -49,6 +50,14 @@ export const POST: RequestHandler = async (event) => {
 
 		// Reiniciar límite de velocidad en registro exitoso
 		RateLimitService.reset(clientIp, input.email, AUTH_RATE_LIMITS.REGISTER);
+
+		if (usuarioCreado.id_usuario) {
+			await notificarNuevaCuentaInstitucionAdmin({
+				usuarioId: usuarioCreado.id_usuario,
+				username: usuarioCreado.username,
+				email: input.email
+			});
+		}
 
 		return json({ usuario: usuarioCreado });
 	} catch (error) {

--- a/app/src/routes/api/registro/verificacion/+server.ts
+++ b/app/src/routes/api/registro/verificacion/+server.ts
@@ -2,6 +2,7 @@ import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { supabaseAdmin } from '$lib/infrastructure/supabase/admin-client';
 import { prisma } from '$lib/infrastructure/prisma/client';
+import { notificarSolicitudVerificacionAdmin } from '$lib/server/servicio-notificaciones-admin';
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	try {
@@ -110,6 +111,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			});
 
 			return verificacion;
+		});
+
+		await notificarSolicitudVerificacionAdmin({
+			usuarioId: usuarioIdInt,
+			username: usuarioSesion.username,
+			tipoSolicitud: 'institucional',
+			cantidadArchivos: files.length
 		});
 
 		return json({

--- a/app/src/routes/api/reportes/+server.ts
+++ b/app/src/routes/api/reportes/+server.ts
@@ -6,6 +6,7 @@ import { PostgresHistorialDeCambiosRepository } from '$lib/infrastructure/supaba
 import { CrearReporte } from '$lib/domain/use-cases/reportes/CrearReporte';
 import { ListarReportes } from '$lib/domain/use-cases/reportes/ListarReportes';
 import { MotivoReporte } from '$lib/domain/types/Reporte';
+import { notificarNuevoReporteAdmin } from '$lib/server/servicio-notificaciones-admin';
 
 // POST /api/reportes — Crear un reporte (cualquier usuario autenticado)
 export const POST: RequestHandler = async ({ request, locals }) => {
@@ -51,6 +52,14 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			motivo: data.motivo as MotivoReporte,
 			descripcion: data.descripcion,
 			reportante_id: usuario.id_usuario!
+		});
+
+		await notificarNuevoReporteAdmin({
+			tipoObjeto: data.tipo_objeto as 'Usuario' | 'Proyecto',
+			idObjeto: id_objeto,
+			motivo: String(data.motivo),
+			reportanteId: usuario.id_usuario!,
+			reportanteUsername: usuario.username
 		});
 
 		return json({ success: true, reporte }, { status: 201 });

--- a/app/src/routes/api/verificaciones/+server.ts
+++ b/app/src/routes/api/verificaciones/+server.ts
@@ -1,6 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { PostgresVerificacionRepository } from '$lib/infrastructure/supabase/postgres/verificacion.repo';
 import { SolicitarVerificacion } from '$lib/domain/use-cases/verificacion/SolicitarVerificacion';
+import { notificarSolicitudVerificacionAdmin } from '$lib/server/servicio-notificaciones-admin';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
 	if (!locals.usuario?.id_usuario || !locals.usuario.rol) {
@@ -43,6 +44,14 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		const repo = new PostgresVerificacionRepository();
 		const useCase = new SolicitarVerificacion(repo);
 		const row = await useCase.execute(locals.usuario.id_usuario, locals.usuario.id_usuario, tipo);
+
+		await notificarSolicitudVerificacionAdmin({
+			usuarioId: locals.usuario.id_usuario,
+			username: locals.usuario.username,
+			tipoSolicitud: String(tipo),
+			cantidadArchivos: 0
+		});
+
 		return json(row, { status: 201 });
 	} catch (e: unknown) {
 		const msg = e instanceof Error ? e.message : 'Error interno';


### PR DESCRIPTION
# 🚀 Pull Request – Conectando Corazones
## Resumen
- agrega `servicio-notificaciones-admin` para centralizar envío de alertas de correo a administradores usando Resend
- dispara notificaciones en alta institucional, solicitudes de verificación, creación de reportes y escalamiento automático de proyectos a auditoría
- documenta asuntos, payloads y variables de entorno en `app/NOTIFICACIONES_ADMIN_EMAIL.md`

## Test plan
- [x] configurar `RESEND_API_KEY` y `ADMIN_ALERTS_EMAILS` para entorno de demo
- [x] validar envío directo vía API de Resend en modo sandbox
- [x] revisar lint de archivos tocados
- [ ] probar  cada trigger (registro institución, verificación, reporte, auditoría)